### PR TITLE
Add Qt helper functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - CONDA_DEPENDENCIES="pyqt pytest mock pytest-cov"
     - PIP_DEPENDENCIES="qtpy coveralls"
+    - SETUP_XVFB=True
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ python:
 
 env:
   global:
-    - CONDA_DEPENDENCIES="pyqt pytest mock coveralls pytest-cov"
-    - PIP_DEPENDENCIES="qtpy"
+    - CONDA_DEPENDENCIES="pyqt pytest mock pytest-cov"
+    - PIP_DEPENDENCIES="qtpy coveralls"
 
 matrix:
   include:
@@ -20,8 +20,8 @@ matrix:
     # Make sure that things run fine without any Qt framework
     - python: 3.5
       env:
-        - CONDA_DEPENDENCIES="pytest mock coveralls pytest-cov"
-        - PIP_DEPENDENCIES=""
+        - CONDA_DEPENDENCIES="pytest mock pytest-cov"
+        - PIP_DEPENDENCIES="coveralls"
 
 install:
   - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ env:
     - CONDA_DEPENDENCIES="pyqt pytest mock coveralls pytest-cov"
     - PIP_DEPENDENCIES="qtpy"
 
+matrix:
+  include:
+
+    # Make sure that things run fine without any Qt framework
+    - python: 3.5
+      env:
+        - CONDA_DEPENDENCIES="pytest mock coveralls pytest-cov"
+        - PIP_DEPENDENCIES=""
+
 install:
   - git clone git://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: python
 sudo: false
 
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,14 @@ python:
   - 3.4
   - 3.5
 
+env:
+  global:
+    - CONDA_DEPENDENCIES="pyqt pytest mock coveralls pytest-cov"
+    - PIP_DEPENDENCIES="qtpy"
+
 install:
-  - pip install pytest mock coveralls pytest-cov
+  - git clone git://github.com/astropy/ci-helpers.git
+  - source ci-helpers/travis/setup_conda.sh
 
 script:
   - py.test --cov echo echo

--- a/echo/__init__.py
+++ b/echo/__init__.py
@@ -1,1 +1,1 @@
-from .core import *
+from .core import *  # noqa

--- a/echo/conftest.py
+++ b/echo/conftest.py
@@ -1,13 +1,22 @@
 from __future__ import absolute_import, division, print_function
 
-from qtpy import QtWidgets
-
 qapp = None
 
 
 def get_qapp():
     global qapp
+    from qtpy import QtWidgets
     qapp = QtWidgets.QApplication.instance()
     if qapp is None:
         qapp = QtWidgets.QApplication([''])
     return qapp
+
+
+def pytest_configure(config):
+
+    try:
+        from qtpy import QtWidgets  # noqa
+    except ImportError:
+        pass
+    else:
+        app = get_qapp()  # noqa

--- a/echo/core.py
+++ b/echo/core.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from contextlib import contextmanager
 from weakref import WeakKeyDictionary
 
@@ -56,7 +58,7 @@ class CallbackProperty(object):
     def __set__(self, instance, value):
         try:
             old = self.__get__(instance)
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             old = None
         self._setter(instance, value)
         new = self.__get__(instance)

--- a/echo/qt/__init__.py
+++ b/echo/qt/__init__.py
@@ -1,0 +1,1 @@
+from .connect import *   # noqa

--- a/echo/qt/autoconnect.py
+++ b/echo/qt/autoconnect.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import, division, print_function
+
+from qtpy import QtWidgets
+
+from echo.qt.connect import (connect_checkable_button,
+                             connect_value,
+                             connect_combo_data,
+                             connect_combo_text,
+                             connect_float_text,
+                             connect_text)
+
+__all__ = ['autoconnect_callbacks_to_qt']
+
+HANDLERS = {}
+HANDLERS['value'] = connect_value
+HANDLERS['valuetext'] = connect_float_text
+HANDLERS['bool'] = connect_checkable_button
+HANDLERS['text'] = connect_text
+HANDLERS['combodata'] = connect_combo_data
+HANDLERS['combotext'] = connect_combo_text
+
+
+def autoconnect_callbacks_to_qt(instance, widget, connect_kwargs={}):
+    """
+    Given a class instance with callback properties and a Qt widget/window,
+    connect callback properties to Qt widgets automatically.
+
+    The matching is done based on the objectName of the Qt widgets. Qt widgets
+    that need to be connected should be named using the syntax ``type_name``
+    where ``type`` describes the kind of matching to be done, and ``name``
+    matches the name of a callback property. By default, the types can be:
+
+    * ``value``: the callback property is linked to a Qt widget that has
+      ``value`` and ``setValue`` methods. Note that for this type, two
+      additional keyword arguments can be specified using ``connect_kwargs``
+      (see below): these are ``value_range``, which is used for cases where
+      the Qt widget is e.g. a slider which has a range of values, and you want
+      to map this range of values onto a different range for the callback
+      property, and the second is ``log``, which can be set to `True` if this
+      mapping should be done in log space.
+
+    * ``valuetext``: the callback property is linked to a Qt widget that has
+      ``text`` and ``setText`` methods, and the text is set to a string
+      representation of the value. Note that for this type, an additional
+      argument ``fmt`` can be provided, which gives either the format to use
+      using the ``{}`` syntax, or should be a function that takes a value
+      and returns a string. Optionally, if the Qt widget supports
+      the ``editingFinished`` signal, this signal is connected to the callback
+      property too.
+
+    * ``bool``: the callback property is linked to a Qt widget that has
+      ``isChecked`` and ``setChecked`` methods, such as a checkable button.
+
+    * ``text``: the callback property is linked to a Qt widget that has
+      ``text`` and ``setText`` methods. Optionally, if the Qt widget supports
+      the ``editingFinished`` signal, this signal is connected to the callback
+      property too.
+
+    * ``combodata``: the callback property is linked to a QComboBox based on
+      the ``userData`` of the entries in the combo box.
+
+    * ``combotext``: the callback property is linked to a QComboBox based on
+      the label of the entries in the combo box.
+
+    Applications can also define additional mappings between type and
+    auto-linking. To do this, simply add a new entry to the ``HANDLERS`` object::
+
+        >>> from glue.echo.qt.autoconnect import HANDLERS
+        >>> HANDLERS['color'] = connect_color
+
+    The handler function (``connect_color`` in the example above) should take
+    the following arguments: the instance the callback property is attached to,
+    the name of the callback property, the Qt widget, and optionally some
+    keyword arguments.
+
+    When calling ``autoconnect_callbacks_to_qt``, you can specify
+    ``connect_kwargs``, where each key should be a valid callback property name,
+    and which gives any additional keyword arguments that can be taken by the
+    connect functions, as described above. These include for example
+    ``value_range``, ``log``, and ``fmt``.
+
+    This function is especially useful when defining ui files, since widget
+    objectNames can be easily set during the editing process.
+    """
+
+    if not hasattr(widget, 'children'):
+        return
+
+    for child in widget.findChildren(QtWidgets.QWidget):
+        full_name = child.objectName()
+        if '_' in full_name:
+            wtype, wname = full_name.split('_', 1)
+            kwargs = connect_kwargs.get(wname, {})
+            if hasattr(instance, wname):
+                if wtype in HANDLERS:
+                    HANDLERS[wtype](instance, wname, child, **kwargs)

--- a/echo/qt/connect.py
+++ b/echo/qt/connect.py
@@ -8,11 +8,11 @@ from functools import partial
 
 from echo import add_callback
 
-__all__ = ['connect_bool_button', 'connect_text', 'connect_combo_data',
+__all__ = ['connect_checkable_button', 'connect_text', 'connect_combo_data',
            'connect_combo_text', 'connect_float_text', 'connect_value']
 
 
-def connect_bool_button(instance, prop, widget):
+def connect_checkable_button(instance, prop, widget):
     """
     Connect a boolean callback property with a Qt button widget.
 

--- a/echo/qt/connect.py
+++ b/echo/qt/connect.py
@@ -1,0 +1,267 @@
+# The functions in this module are used to connect callback properties to Qt
+# widgets.
+
+from __future__ import absolute_import, division, print_function
+
+import math
+from functools import partial
+
+from glue.external.echo import add_callback
+
+__all__ = ['connect_bool_button', 'connect_text', 'connect_combo_data',
+           'connect_combo_text', 'connect_float_text', 'connect_value']
+
+
+def connect_bool_button(instance, prop, widget):
+    """
+    Connect a boolean callback property with a Qt button widget.
+
+    Parameters
+    ----------
+    instance : object
+        The class instance that the callback property is attached to
+    prop : str
+        The name of the callback property
+    widget : QtWidget
+        The Qt widget to connect. This should implement the ``setChecked``
+        method and the ``toggled`` signal.
+    """
+    add_callback(instance, prop, widget.setChecked)
+    widget.toggled.connect(partial(setattr, instance, prop))
+
+
+def connect_text(instance, prop, widget):
+    """
+    Connect a string callback property with a Qt widget containing text.
+
+    Parameters
+    ----------
+    instance : object
+        The class instance that the callback property is attached to
+    prop : str
+        The name of the callback property
+    widget : QtWidget
+        The Qt widget to connect. This should implement the ``setText`` and
+        ``text`` methods as well optionally the ``editingFinished`` signal.
+    """
+
+    def update_prop():
+        val = widget.text()
+        setattr(instance, prop, val)
+
+    def update_widget(val):
+        widget.setText(val)
+
+    add_callback(instance, prop, update_widget)
+
+    try:
+        widget.editingFinished.connect(update_prop)
+    except AttributeError:
+        pass
+
+    update_widget(getattr(instance, prop))
+
+
+def connect_combo_data(instance, prop, widget):
+    """
+    Connect a callback property with a QComboBox widget based on the userData.
+
+    Parameters
+    ----------
+    instance : object
+        The class instance that the callback property is attached to
+    prop : str
+        The name of the callback property
+    widget : QComboBox
+        The combo box to connect.
+
+    See Also
+    --------
+    connect_combo_text: connect a callback property with a QComboBox widget based on the text.
+    """
+
+    def update_widget(value):
+        try:
+            idx = _find_combo_data(widget, value)
+        except ValueError:
+            if value is None:
+                idx = -1
+            else:
+                raise
+        widget.setCurrentIndex(idx)
+
+    def update_prop(idx):
+        if idx == -1:
+            setattr(instance, prop, None)
+        else:
+            setattr(instance, prop, widget.itemData(idx))
+
+    add_callback(instance, prop, update_widget)
+    widget.currentIndexChanged.connect(update_prop)
+
+    update_widget(getattr(instance, prop))
+
+
+def connect_combo_text(instance, prop, widget):
+    """
+    Connect a callback property with a QComboBox widget based on the text.
+
+    Parameters
+    ----------
+    instance : object
+        The class instance that the callback property is attached to
+    prop : str
+        The name of the callback property
+    widget : QComboBox
+        The combo box to connect.
+
+    See Also
+    --------
+    connect_combo_data: connect a callback property with a QComboBox widget based on the userData.
+    """
+
+    def update_widget(value):
+        try:
+            idx = _find_combo_text(widget, value)
+        except ValueError:
+            if value is None:
+                idx = -1
+            else:
+                raise
+        widget.setCurrentIndex(idx)
+
+    def update_prop(idx):
+        if idx == -1:
+            setattr(instance, prop, None)
+        else:
+            setattr(instance, prop, widget.itemText(idx))
+
+    add_callback(instance, prop, update_widget)
+    widget.currentIndexChanged.connect(update_prop)
+
+    update_widget(getattr(instance, prop))
+
+
+def connect_float_text(instance, prop, widget, fmt):
+    """
+    Connect a numerical callback property with a Qt widget containing text.
+
+    Parameters
+    ----------
+    instance : object
+        The class instance that the callback property is attached to
+    prop : str
+        The name of the callback property
+    widget : QtWidget
+        The Qt widget to connect. This should implement the ``setText`` and
+        ``text`` methods as well optionally the ``editingFinished`` signal.
+    fmt : str or func
+        This should be either a format string (in the ``{}`` notation), or a
+        function that takes a number and returns a string.
+    """
+
+    if isinstance(fmt, callable):
+        format_func = fmt
+    else:
+        def format_func(x):
+            return fmt.format(x)
+
+    def update_prop():
+        val = widget.text()
+        try:
+            setattr(instance, prop, float(val))
+        except ValueError:
+            setattr(instance, prop, 0)
+
+    def update_widget(val):
+        if val is None:
+            val = 0.
+        widget.setText(format_func(val))
+
+    add_callback(instance, prop, update_widget)
+
+    try:
+        widget.editingFinished.connect(update_prop)
+    except AttributeError:
+        pass
+
+    update_widget(getattr(instance, prop))
+
+
+def connect_value(instance, prop, widget, value_range=None, log=False):
+    """
+    Connect a numerical callback property with a Qt widget representing a value.
+
+    Parameters
+    ----------
+    instance : object
+        The class instance that the callback property is attached to
+    prop : str
+        The name of the callback property
+    widget : QtWidget
+        The Qt widget to connect. This should implement the ``setText`` and
+        ``text`` methods as well optionally the ``editingFinished`` signal.
+    value_range : iterable, optional
+        A pair of two values representing the true range of values (since
+        Qt widgets such as sliders can only have values in certain ranges).
+    log : bool, optional
+        Whether the Qt widget value should be mapped to the log of the callback
+        property.
+    """
+
+    if log:
+        if value_range is None:
+            raise ValueError("log option can only be set if value_range is given")
+        else:
+            value_range = math.log10(value_range[0]), math.log10(value_range[1])
+
+    def update_prop():
+        val = widget.value()
+        if value_range is not None:
+            imin, imax = widget.minimum(), widget.maximum()
+            val = (val - imin) / (imax - imin) * (value_range[1] - value_range[0]) + value_range[0]
+        if log:
+            val = 10 ** val
+        setattr(instance, prop, val)
+
+    def update_widget(val):
+        if val is None:
+            widget.setValue(0)
+            return
+        if log:
+            val = math.log10(val)
+        if value_range is not None:
+            imin, imax = widget.minimum(), widget.maximum()
+            val = (val - value_range[0]) / (value_range[1] - value_range[0]) * (imax - imin) + imin
+        widget.setValue(val)
+
+    add_callback(instance, prop, update_widget)
+    widget.valueChanged.connect(update_prop)
+
+    update_widget(getattr(instance, prop))
+
+
+def _find_combo_data(widget, value):
+    """
+    Returns the index in a combo box where itemData == value
+
+    Raises a ValueError if data is not found
+    """
+    i = widget.findData(value)
+    if i == -1:
+        raise ValueError("%s not found in combo box" % value)
+    else:
+        return i
+
+
+def _find_combo_text(widget, value):
+    """
+    Returns the index in a combo box where text == value
+
+    Raises a ValueError if data is not found
+    """
+    i = widget.findText(value)
+    if i == -1:
+        raise ValueError("%s not found in combo box" % value)
+    else:
+        return i

--- a/echo/qt/connect.py
+++ b/echo/qt/connect.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 import math
 from functools import partial
 
-from glue.external.echo import add_callback
+from echo import add_callback
 
 __all__ = ['connect_bool_button', 'connect_text', 'connect_combo_data',
            'connect_combo_text', 'connect_float_text', 'connect_value']
@@ -142,7 +142,7 @@ def connect_combo_text(instance, prop, widget):
     update_widget(getattr(instance, prop))
 
 
-def connect_float_text(instance, prop, widget, fmt):
+def connect_float_text(instance, prop, widget, fmt="{:g}"):
     """
     Connect a numerical callback property with a Qt widget containing text.
 
@@ -160,7 +160,7 @@ def connect_float_text(instance, prop, widget, fmt):
         function that takes a number and returns a string.
     """
 
-    if isinstance(fmt, callable):
+    if callable(fmt):
         format_func = fmt
     else:
         def format_func(x):

--- a/echo/qt/tests/helpers.py
+++ b/echo/qt/tests/helpers.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
+from qtpy import QtWidgets
+
+qapp = None
+
+
+def get_qapp():
+    global qapp
+    qapp = QtWidgets.QApplication.instance()
+    if qapp is None:
+        qapp = QtWidgets.QApplication([''])
+    return qapp

--- a/echo/qt/tests/test_autoconnect.py
+++ b/echo/qt/tests/test_autoconnect.py
@@ -1,0 +1,124 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+try:
+    from qtpy import QtWidgets
+except ImportError:
+    QTPY_INSTALLED = False
+else:
+    QTPY_INSTALLED = True
+
+
+from echo import CallbackProperty
+from echo.qt.tests.helpers import get_qapp
+from echo.qt.autoconnect import autoconnect_callbacks_to_qt
+
+
+@pytest.mark.skipif("not QTPY_INSTALLED")
+def test_autoconnect_callbacks_to_qt():
+
+    app = get_qapp()
+
+    class Data(object):
+        pass
+
+    data1 = Data()
+    data2 = Data()
+
+    class CustomWidget(QtWidgets.QWidget):
+        def __init__(self, parent=None):
+
+            super(CustomWidget, self).__init__(parent=parent)
+
+            self.layout = QtWidgets.QVBoxLayout()
+            self.setLayout(self.layout)
+
+            self.combotext_planet = QtWidgets.QComboBox(objectName='combotext_planet')
+            self.layout.addWidget(self.combotext_planet)
+            self.combotext_planet.addItem('earth')
+            self.combotext_planet.addItem('mars')
+            self.combotext_planet.addItem('jupiter')
+
+            self.combodata_dataset = QtWidgets.QComboBox(objectName='combodata_dataset')
+            self.layout.addWidget(self.combodata_dataset)
+            self.combodata_dataset.addItem('data1', data1)
+            self.combodata_dataset.addItem('data2', data2)
+
+            self.text_name = QtWidgets.QLineEdit(objectName='text_name')
+            self.layout.addWidget(self.text_name)
+
+            self.valuetext_age = QtWidgets.QLineEdit(objectName='valuetext_age')
+            self.layout.addWidget(self.valuetext_age)
+
+            self.value_height = QtWidgets.QSlider(objectName='value_height')
+            self.value_height.setMinimum(0)
+            self.value_height.setMaximum(10)
+            self.layout.addWidget(self.value_height)
+
+            self.bool_log = QtWidgets.QToolButton(objectName='bool_log')
+            self.bool_log.setCheckable(True)
+            self.layout.addWidget(self.bool_log)
+
+    class Person(object):
+        planet = CallbackProperty()
+        dataset = CallbackProperty()
+        name = CallbackProperty()
+        age = CallbackProperty()
+        height = CallbackProperty()
+        log = CallbackProperty()
+
+    widget = CustomWidget()
+
+    person = Person()
+
+    connect_kwargs = {'height': {'value_range': (0, 100)},
+                      'age': {'fmt':'{:.2f}'}}
+
+    autoconnect_callbacks_to_qt(person, widget, connect_kwargs=connect_kwargs)
+
+    # Check that modifying things in the Qt widget updates the callback properties
+
+    widget.combotext_planet.setCurrentIndex(2)
+    assert person.planet == 'jupiter'
+
+    widget.combodata_dataset.setCurrentIndex(1)
+    assert person.dataset is data2
+
+    widget.text_name.setText('Lovelace')
+    widget.text_name.editingFinished.emit()
+    assert person.name == 'Lovelace'
+
+    widget.valuetext_age.setText('76')
+    widget.valuetext_age.editingFinished.emit()
+    assert person.age == 76
+
+    widget.value_height.setValue(7)
+    assert person.height == 70
+
+    widget.bool_log.setChecked(True)
+    assert person.log
+
+    # Check that modifying the callback properties updates the Qt widget
+
+    person.planet = 'mars'
+    assert widget.combotext_planet.currentIndex() == 1
+
+    person.dataset = data1
+    assert widget.combodata_dataset.currentIndex() == 0
+
+    person.name = 'Curie'
+    assert widget.text_name.text() == 'Curie'
+
+    person.age = 66.3
+    assert widget.valuetext_age.text() == '66.30'
+
+    person.height = 54
+    assert widget.value_height.value() == 5
+
+    person.log = False
+    assert not widget.bool_log.isChecked()
+
+
+
+    person.dataset = data1

--- a/echo/qt/tests/test_autoconnect.py
+++ b/echo/qt/tests/test_autoconnect.py
@@ -11,14 +11,11 @@ else:
 
 
 from echo import CallbackProperty
-from echo.qt.tests.helpers import get_qapp
 from echo.qt.autoconnect import autoconnect_callbacks_to_qt
 
 
 @pytest.mark.skipif("not QTPY_INSTALLED")
 def test_autoconnect_callbacks_to_qt():
-
-    app = get_qapp()
 
     class Data(object):
         pass
@@ -118,7 +115,3 @@ def test_autoconnect_callbacks_to_qt():
 
     person.log = False
     assert not widget.bool_log.isChecked()
-
-
-
-    person.dataset = data1

--- a/echo/qt/tests/test_autoconnect.py
+++ b/echo/qt/tests/test_autoconnect.py
@@ -9,9 +9,10 @@ except ImportError:
 else:
     QTPY_INSTALLED = True
 
+if QTPY_INSTALLED:
+    from echo.qt.autoconnect import autoconnect_callbacks_to_qt
 
 from echo import CallbackProperty
-from echo.qt.autoconnect import autoconnect_callbacks_to_qt
 
 
 @pytest.mark.skipif("not QTPY_INSTALLED")

--- a/echo/qt/tests/test_connect.py
+++ b/echo/qt/tests/test_connect.py
@@ -1,0 +1,194 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from qtpy import QtWidgets
+
+from echo import CallbackProperty
+from echo.qt.connect import (connect_bool_button, connect_text,
+                             connect_combo_data, connect_combo_text,
+                             connect_float_text, connect_value)
+from echo.qt.tests.helpers import get_qapp
+
+
+def setup_module(module):
+    get_qapp()
+
+
+def test_connect_bool_button():
+
+    class Test(object):
+        a = CallbackProperty()
+
+    t = Test()
+
+    box = QtWidgets.QCheckBox()
+    connect_bool_button(t, 'a', box)
+
+    box.setChecked(True)
+    assert t.a
+
+    box.setChecked(False)
+    assert not t.a
+
+    t.a = True
+    assert box.isChecked()
+
+    t.a = False
+    assert not box.isChecked()
+
+
+def test_connect_text():
+
+    class Test(object):
+        a = CallbackProperty()
+        b = CallbackProperty()
+
+    t = Test()
+
+    box = QtWidgets.QLineEdit()
+    connect_text(t, 'a', box)
+
+    label = QtWidgets.QLabel()
+    connect_text(t, 'b', label)
+
+    box.setText('test1')
+    box.editingFinished.emit()
+    assert t.a == 'test1'
+
+    t.a = 'test3'
+    assert box.text() == 'test3'
+
+    t.b = 'test4'
+    assert label.text() == 'test4'
+
+
+def test_connect_combo():
+
+    class Test(object):
+        a = CallbackProperty()
+        b = CallbackProperty()
+
+    t = Test()
+
+    combo = QtWidgets.QComboBox()
+    combo.addItem('label1', 4)
+    combo.addItem('label2', 3.5)
+
+    connect_combo_text(t, 'a', combo)
+    connect_combo_data(t, 'b', combo)
+
+    combo.setCurrentIndex(1)
+    assert t.a == 'label2'
+    assert t.b == 3.5
+
+    combo.setCurrentIndex(0)
+    assert t.a == 'label1'
+    assert t.b == 4
+
+    combo.setCurrentIndex(-1)
+    assert t.a is None
+    assert t.b is None
+
+    t.a = 'label2'
+    assert combo.currentIndex() == 1
+
+    t.a = 'label1'
+    assert combo.currentIndex() == 0
+
+    with pytest.raises(ValueError) as exc:
+        t.a = 'label3'
+    assert exc.value.args[0] == 'label3 not found in combo box'
+
+    t.a = None
+    assert combo.currentIndex() == -1
+
+    t.b = 3.5
+    assert combo.currentIndex() == 1
+
+    t.b = 4
+    assert combo.currentIndex() == 0
+
+    with pytest.raises(ValueError) as exc:
+        t.b = 2
+    assert exc.value.args[0] == '2 not found in combo box'
+
+    t.b = None
+    assert combo.currentIndex() == -1
+
+
+def test_connect_float_text():
+
+    class Test(object):
+        a = CallbackProperty()
+        b = CallbackProperty()
+        c = CallbackProperty()
+
+    t = Test()
+
+    line1 = QtWidgets.QLineEdit()
+    line2 = QtWidgets.QLineEdit()
+    line3 = QtWidgets.QLabel()
+
+    def fmt_func(x):
+        return str(int(round(x)))
+
+    connect_float_text(t, 'a', line1)
+    connect_float_text(t, 'b', line2, fmt="{:5.2f}")
+    connect_float_text(t, 'c', line3, fmt=fmt_func)
+
+    for line in (line1, line2):
+
+        line1.setText('1.0')
+        line1.editingFinished.emit()
+        assert t.a == 1.0
+
+        line1.setText('banana')
+        line1.editingFinished.emit()
+        assert t.a == 0.0
+
+    t.a = 3.
+    assert line1.text() == '3'
+
+    t.b = 5.211
+    assert line2.text() == ' 5.21'
+
+    t.c = -2.222
+    assert line3.text() == '-2'
+
+
+def test_connect_value():
+
+    class Test(object):
+        a = CallbackProperty()
+        b = CallbackProperty()
+        c = CallbackProperty()
+
+    t = Test()
+
+    slider = QtWidgets.QSlider()
+    slider.setMinimum(0)
+    slider.setMaximum(100)
+
+    connect_value(t, 'a', slider)
+    connect_value(t, 'b', slider, value_range=(0, 10))
+
+    with pytest.raises(Exception) as exc:
+        connect_value(t, 'c', slider, log=True)
+    assert exc.value.args[0] == "log option can only be set if value_range is given"
+
+    connect_value(t, 'c', slider, value_range=(0.01, 100), log=True)
+
+    slider.setValue(25)
+    assert t.a == 25
+    assert t.b == 2.5
+    assert t.c == 0.1
+
+    t.a = 30
+    assert slider.value() == 30
+
+    t.b = 8.5
+    assert slider.value() == 85
+
+    t.c = 10
+    assert slider.value() == 75

--- a/echo/qt/tests/test_connect.py
+++ b/echo/qt/tests/test_connect.py
@@ -2,7 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from qtpy import QtWidgets
+try:
+    from qtpy import QtWidgets
+except ImportError:
+    QTPY_INSTALLED=False
+else:
+    QTPY_INSTALLED=True
 
 from echo import CallbackProperty
 from echo.qt.connect import (connect_bool_button, connect_text,
@@ -15,6 +20,7 @@ def setup_module(module):
     get_qapp()
 
 
+@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_bool_button():
 
     class Test(object):
@@ -38,6 +44,7 @@ def test_connect_bool_button():
     assert not box.isChecked()
 
 
+@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_text():
 
     class Test(object):
@@ -63,6 +70,7 @@ def test_connect_text():
     assert label.text() == 'test4'
 
 
+@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_combo():
 
     class Test(object):
@@ -117,6 +125,7 @@ def test_connect_combo():
     assert combo.currentIndex() == -1
 
 
+@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_float_text():
 
     class Test(object):
@@ -157,6 +166,7 @@ def test_connect_float_text():
     assert line3.text() == '-2'
 
 
+@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_value():
 
     class Test(object):

--- a/echo/qt/tests/test_connect.py
+++ b/echo/qt/tests/test_connect.py
@@ -5,19 +5,14 @@ import pytest
 try:
     from qtpy import QtWidgets
 except ImportError:
-    QTPY_INSTALLED=False
+    QTPY_INSTALLED = False
 else:
-    QTPY_INSTALLED=True
+    QTPY_INSTALLED = True
 
 from echo import CallbackProperty
 from echo.qt.connect import (connect_checkable_button, connect_text,
                              connect_combo_data, connect_combo_text,
                              connect_float_text, connect_value)
-from echo.qt.tests.helpers import get_qapp
-
-
-def setup_module(module):
-    get_qapp()
 
 
 @pytest.mark.skipif("not QTPY_INSTALLED")

--- a/echo/qt/tests/test_connect.py
+++ b/echo/qt/tests/test_connect.py
@@ -10,7 +10,7 @@ else:
     QTPY_INSTALLED=True
 
 from echo import CallbackProperty
-from echo.qt.connect import (connect_bool_button, connect_text,
+from echo.qt.connect import (connect_checkable_button, connect_text,
                              connect_combo_data, connect_combo_text,
                              connect_float_text, connect_value)
 from echo.qt.tests.helpers import get_qapp
@@ -21,7 +21,7 @@ def setup_module(module):
 
 
 @pytest.mark.skipif("not QTPY_INSTALLED")
-def test_connect_bool_button():
+def test_connect_checkable_button():
 
     class Test(object):
         a = CallbackProperty()
@@ -29,7 +29,7 @@ def test_connect_bool_button():
     t = Test()
 
     box = QtWidgets.QCheckBox()
-    connect_bool_button(t, 'a', box)
+    connect_checkable_button(t, 'a', box)
 
     box.setChecked(True)
     assert t.a

--- a/echo/tests/test_echo.py
+++ b/echo/tests/test_echo.py
@@ -1,5 +1,7 @@
-from mock import MagicMock
+from __future__ import absolute_import, division, print_function
+
 import pytest
+from mock import MagicMock
 
 from echo import (CallbackProperty, add_callback,
                   remove_callback, delay_callback,
@@ -258,3 +260,12 @@ def test_decorator_form():
     test.assert_called_once_with(10)
 
     assert stub.prop == 10
+
+
+def test_docstring():
+
+    class Simple(object):
+        a = CallbackProperty(docstring='important')
+
+    s = Simple()
+    assert type(s).a.__doc__ == 'important'


### PR DESCRIPTION
This adds functions that allow callback properties to be connected to Qt widgets. This does not add any dependency on Qt at runtime if it is not needed.

This also includes a new function ``autoconnect_callbacks_to_qt`` which, given a class with callback properties and a Qt widget, will infer automatically the connections that need to be made based on the name of the Qt widgets and the callback properties (see the docstring for that function). This is a step towards the state handling describing by @ChrisBeaumont in https://github.com/glue-viz/glue/issues/775 - I have a branch where I currently have 'state' classes which are basically just classes with lots of CallbackProperties. This auto-connect function significantly reduces the amount of boilerplate code that needs to be written to set up all the connections.

I haven't yet included the widget property **classes**, but will be thinking about the best way to do this. Currently, they duplicate some of the code in the connect_ functions.