### PR TITLE
Added HasCallbackProperties and ListCallbackProperty

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+omit = echo/tests/*, echo/conftest.py, echo/qt/tests/*

--- a/doc/gui.rst
+++ b/doc/gui.rst
@@ -18,7 +18,7 @@ Let's assume we have a simple Qt window with a single checkbox::
     class MySimpleWindow(QtWidgets.QMainWindow):
 
         def __init__(self, parent=None):
-            super().__init__(parent=parent)
+            super(MySimpleWindow, self).__init__(parent=parent)
             self.checkbox = QtWidgets.QCheckBox()
 
 We can now add a callback property to the class and connect the property to the
@@ -33,7 +33,7 @@ Qt checkbox::
         active = CallbackProperty(True)
 
         def __init__(self, parent=None):
-            super().__init__(parent=parent)
+            super(MySimpleWindow, self).__init__(parent=parent)
             self.checkbox = QtWidgets.QCheckBox()
             self.setCentralWidget(self.checkbox)
             connect_checkable_button(self, 'active', self.checkbox)

--- a/echo/__init__.py
+++ b/echo/__init__.py
@@ -1,1 +1,2 @@
 from .core import *  # noqa
+from .list import *  # noqa

--- a/echo/core.py
+++ b/echo/core.py
@@ -205,7 +205,7 @@ class HasCallbackProperties(object):
                 prop = getattr(type(self), name)
                 prop.add_callback(self, callback, echo_old=echo_old)
             else:
-                raise TypeError('attribute {0} is not a callback property'.format(name))
+                raise TypeError("attribute '{0}' is not a callback property".format(name))
 
     def remove_callback(self, name, callback):
         """
@@ -234,7 +234,7 @@ class HasCallbackProperties(object):
                 except ValueError:
                     pass  # Be forgiving if callback was already removed before
             else:
-                raise TypeError('attribute {0} is not a callback property'.format(name))
+                raise TypeError("attribute '{0}' is not a callback property".format(name))
 
     def is_callback_property(self, name):
         return isinstance(getattr(type(self), name, None), CallbackProperty)

--- a/echo/core.py
+++ b/echo/core.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from contextlib import contextmanager
 from weakref import WeakKeyDictionary
-
+from functools import partial
 
 __all__ = ['CallbackProperty', 'callback_property',
            'add_callback', 'remove_callback',
@@ -192,8 +192,8 @@ class HasCallbackProperties(object):
             (the default), will be invoked as ``func(new)``
         """
         if name == '*':
-            for prop in self.iter_callback_properties():
-                prop.add_callback(self, callback, echo_old=echo_old)
+            for name, prop in self.iter_callback_properties():
+                prop.add_callback(self, partial(callback, name), echo_old=echo_old)
         else:
             if self.is_callback_property(name):
                 prop = getattr(type(self), name)
@@ -215,7 +215,7 @@ class HasCallbackProperties(object):
             The callback function to remove
         """
         if name == '*':
-            for prop in self.iter_callback_properties():
+            for name, prop in self.iter_callback_properties():
                 try:
                     prop.remove_callback(self, callback)
                 except ValueError:
@@ -234,7 +234,7 @@ class HasCallbackProperties(object):
     def iter_callback_properties(self):
         for name in dir(self):
             if self.is_callback_property(name):
-                yield getattr(type(self), name)
+                yield name, getattr(type(self), name)
 
 
 def add_callback(instance, prop, callback, echo_old=False):

--- a/echo/list.py
+++ b/echo/list.py
@@ -86,6 +86,26 @@ class CallbackList(list):
             super(CallbackList, self).clear()
             self.callback()
 
+    else:
+
+        def __setslice__(self, start, end, new_values):
+
+            slc = slice(start, end)
+
+            old_values = self[slc]
+
+            for old_value in old_values:
+                if isinstance(old_value, HasCallbackProperties):
+                    old_value.remove_callback('*', self.callback)
+
+            for value in new_values:
+                if isinstance(value, HasCallbackProperties):
+                    value.add_callback('*', self.callback)
+
+            super(CallbackList, self).__setslice__(start, end, new_values)
+            self.callback()
+
+
 
 class ListCallbackProperty(CallbackProperty):
     """

--- a/echo/list.py
+++ b/echo/list.py
@@ -12,30 +12,30 @@ class CallbackList(list):
     """
 
     def __init__(self, callback, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(CallbackList, self).__init__(*args, **kwargs)
         self.callback = callback
 
     def append(self, value):
-        super().append(value)
+        super(CallbackList, self).append(value)
         if isinstance(value, HasCallbackProperties):
             value.add_callback('*', self.callback)
         self.callback()
 
     def extend(self, iterable):
-        super().extend(iterable)
+        super(CallbackList, self).extend(iterable)
         for item in iterable:
             if isinstance(item, HasCallbackProperties):
                 item.add_callback('*', self.callback)
         self.callback()
 
     def insert(self, index, value):
-        super().insert(index, value)
+        super(CallbackList, self).insert(index, value)
         if isinstance(value, HasCallbackProperties):
             value.add_callback('*', self.callback)
         self.callback()
 
     def pop(self, index=-1):
-        result = super().pop(index)
+        result = super(CallbackList, self).pop(index)
         if isinstance(result, HasCallbackProperties):
             result.remove_callback('*', self.callback)
         self.callback()
@@ -44,15 +44,15 @@ class CallbackList(list):
     def remove(self, value):
         if isinstance(value, HasCallbackProperties):
             value.remove_callback('*', self.callback)
-        super().remove(value)
+        super(CallbackList, self).remove(value)
         self.callback()
 
     def reverse(self):
-        super().reverse()
+        super(CallbackList, self).reverse()
         self.callback()
 
     def sort(self, key=None, reverse=False):
-        super().sort(key=key, reverse=reverse)
+        super(CallbackList, self).sort(key=key, reverse=reverse)
         self.callback()
 
     if sys.version_info[0] >= 3:
@@ -61,7 +61,7 @@ class CallbackList(list):
             for item in self:
                 if isinstance(item, HasCallbackProperties):
                     item.remove_callback('*', self.callback)
-            super().clear()
+            super(CallbackList, self).clear()
             self.callback()
 
 
@@ -73,7 +73,7 @@ class ListCallbackProperty(CallbackProperty):
     def _default_getter(self, instance, owner=None):
         if instance not in self._values:
             self._default_setter(instance, [])
-        return super()._default_getter(instance, owner)
+        return super(ListCallbackProperty, self)._default_getter(instance, owner)
 
     def _default_setter(self, instance, value):
 
@@ -84,4 +84,4 @@ class ListCallbackProperty(CallbackProperty):
             self.notify(instance, value, value)
 
         wrapped_list = CallbackList(callback, value)
-        super()._default_setter(instance, wrapped_list)
+        super(ListCallbackProperty, self)._default_setter(instance, wrapped_list)

--- a/echo/list.py
+++ b/echo/list.py
@@ -55,6 +55,28 @@ class CallbackList(list):
         super(CallbackList, self).sort(key=key, reverse=reverse)
         self.callback()
 
+    def __setitem__(self, slc, new_value):
+
+        old_values = self[slc]
+        if not isinstance(slc, slice):
+            old_values = [old_values]
+
+        for old_value in old_values:
+            if isinstance(old_value, HasCallbackProperties):
+                old_value.remove_callback('*', self.callback)
+
+        if isinstance(slc, slice):
+            new_values = new_value
+        else:
+            new_values = [new_value]
+
+        for value in new_values:
+            if isinstance(value, HasCallbackProperties):
+                value.add_callback('*', self.callback)
+
+        super(CallbackList, self).__setitem__(slc, new_value)
+        self.callback()
+
     if sys.version_info[0] >= 3:
 
         def clear(self):

--- a/echo/list.py
+++ b/echo/list.py
@@ -1,0 +1,87 @@
+import sys
+
+from echo import CallbackProperty, HasCallbackProperties
+
+
+class CallbackList(list):
+    """
+    A list that calls a callback function when it is modified.
+
+    The first argument should be the callback function (which takes no
+    arguments), and subsequent arguments are as for `list`.
+    """
+
+    def __init__(self, callback, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.callback = callback
+
+    def append(self, value):
+        super().append(value)
+        if isinstance(value, HasCallbackProperties):
+            value.add_callback('*', self.callback)
+        self.callback()
+
+    def extend(self, iterable):
+        super().extend(iterable)
+        for item in iterable:
+            if isinstance(item, HasCallbackProperties):
+                item.add_callback('*', self.callback)
+        self.callback()
+
+    def insert(self, index, value):
+        super().insert(index, value)
+        if isinstance(value, HasCallbackProperties):
+            value.add_callback('*', self.callback)
+        self.callback()
+
+    def pop(self, index=-1):
+        result = super().pop(index)
+        if isinstance(result, HasCallbackProperties):
+            result.remove_callback('*', self.callback)
+        self.callback()
+        return result
+
+    def remove(self, value):
+        if isinstance(value, HasCallbackProperties):
+            value.remove_callback('*', self.callback)
+        super().remove(value)
+        self.callback()
+
+    def reverse(self):
+        super().reverse()
+        self.callback()
+
+    def sort(self, key=None, reverse=False):
+        super().sort(key=key, reverse=reverse)
+        self.callback()
+
+    if sys.version_info[0] >= 3:
+
+        def clear(self):
+            for item in self:
+                if isinstance(item, HasCallbackProperties):
+                    item.remove_callback('*', self.callback)
+            super().clear()
+            self.callback()
+
+
+class ListCallbackProperty(CallbackProperty):
+    """
+    A list property that calls callbacks when its contents are modified
+    """
+
+    def _default_getter(self, instance, owner=None):
+        if instance not in self._values:
+            self._default_setter(instance, [])
+        return super()._default_getter(instance, owner)
+
+    def _default_setter(self, instance, value):
+
+        if not isinstance(value, list):
+            raise TypeError('callback property should be a list')
+
+        def callback(*args):
+            self.notify(instance, value, value)
+
+        wrapped_list = CallbackList(callback, value)
+        super()._default_setter(instance, wrapped_list)

--- a/echo/qt/__init__.py
+++ b/echo/qt/__init__.py
@@ -1,1 +1,2 @@
 from .connect import *   # noqa
+from .autoconnect import *  # noqa

--- a/echo/qt/__init__.py
+++ b/echo/qt/__init__.py
@@ -1,2 +1,8 @@
+try:
+    import pytest
+    pytest.importorskip('qtpy')
+except ImportError:
+    pass
+
 from .connect import *   # noqa
 from .autoconnect import *  # noqa

--- a/echo/qt/tests/test_autoconnect.py
+++ b/echo/qt/tests/test_autoconnect.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 try:
-    from qtpy import QtWidgets
+    from qtpy import QtWidgets, QtGui
 except ImportError:
     QTPY_INSTALLED = False
 else:
@@ -116,3 +116,18 @@ def test_autoconnect_callbacks_to_qt():
 
     person.log = False
     assert not widget.bool_log.isChecked()
+
+
+def test_autoconnect_with_empty_qt_item():
+
+    # The following test just makes sure that if a widget without children
+    # is ever passed to autoconnect_callbacks_to_qt, things don't crash
+
+    widget = QtGui.QPalette()
+
+    class Person(object):
+        name = CallbackProperty()
+
+    person = Person()
+
+    autoconnect_callbacks_to_qt(person, widget)

--- a/echo/qt/tests/test_autoconnect.py
+++ b/echo/qt/tests/test_autoconnect.py
@@ -118,6 +118,7 @@ def test_autoconnect_callbacks_to_qt():
     assert not widget.bool_log.isChecked()
 
 
+@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_autoconnect_with_empty_qt_item():
 
     # The following test just makes sure that if a widget without children

--- a/echo/qt/tests/test_autoconnect.py
+++ b/echo/qt/tests/test_autoconnect.py
@@ -1,21 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-import pytest
+from qtpy import QtWidgets, QtGui
 
-try:
-    from qtpy import QtWidgets, QtGui
-except ImportError:
-    QTPY_INSTALLED = False
-else:
-    QTPY_INSTALLED = True
-
-if QTPY_INSTALLED:
-    from echo.qt.autoconnect import autoconnect_callbacks_to_qt
-
+from echo.qt.autoconnect import autoconnect_callbacks_to_qt
 from echo import CallbackProperty
 
 
-@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_autoconnect_callbacks_to_qt():
 
     class Data(object):
@@ -117,8 +107,6 @@ def test_autoconnect_callbacks_to_qt():
     person.log = False
     assert not widget.bool_log.isChecked()
 
-
-@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_autoconnect_with_empty_qt_item():
 
     # The following test just makes sure that if a widget without children

--- a/echo/qt/tests/test_connect.py
+++ b/echo/qt/tests/test_connect.py
@@ -2,12 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-try:
-    from qtpy import QtWidgets
-except ImportError:
-    QTPY_INSTALLED = False
-else:
-    QTPY_INSTALLED = True
+from qtpy import QtWidgets
 
 from echo import CallbackProperty
 from echo.qt.connect import (connect_checkable_button, connect_text,
@@ -15,7 +10,6 @@ from echo.qt.connect import (connect_checkable_button, connect_text,
                              connect_float_text, connect_value)
 
 
-@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_checkable_button():
 
     class Test(object):
@@ -39,7 +33,6 @@ def test_connect_checkable_button():
     assert not box.isChecked()
 
 
-@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_text():
 
     class Test(object):
@@ -65,7 +58,6 @@ def test_connect_text():
     assert label.text() == 'test4'
 
 
-@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_combo():
 
     class Test(object):
@@ -120,7 +112,6 @@ def test_connect_combo():
     assert combo.currentIndex() == -1
 
 
-@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_float_text():
 
     class Test(object):
@@ -161,7 +152,6 @@ def test_connect_float_text():
     assert line3.text() == '-2'
 
 
-@pytest.mark.skipif("not QTPY_INSTALLED")
 def test_connect_value():
 
     class Test(object):

--- a/echo/tests/test_core.py
+++ b/echo/tests/test_core.py
@@ -279,6 +279,7 @@ class State(HasCallbackProperties):
     c = CallbackProperty()
     d = 1
 
+
 def test_class_add_remove_callback():
 
     state = State()
@@ -286,41 +287,49 @@ def test_class_add_remove_callback():
     class mockclass(object):
         def __init__(self):
             self.call_count = 0
+            self.args = ()
+            self.kwargs = {}
         def __call__(self, *args, **kwargs):
-            if self.call_count == 1:
-                raise ValueError("what why are we here")
+            self.args = args
+            self.kwargs = kwargs
             self.call_count += 1
 
     test1 = mockclass()
     state.add_callback('a', test1)
 
     # Deliberaty adding to c twice to make sure it works fine with two callbacks
-    test2 = MagicMock()
-    state.add_callback('c', test2)
+    test2 = mockclass()
+    state.add_callback('c', test2, echo_name=True)
 
-    test3 = MagicMock()
-    state.add_callback('c', test3)
+    test3 = mockclass()
+    state.add_callback('c', test3, echo_old=True)
 
-    test4 = MagicMock()
-    state.add_callback('*', test4)
+    test4 = mockclass()
+    state.add_callback('*', test4, echo_name=True)
 
     state.a = 1
     assert test1.call_count == 1
+    assert test1.args == (1,)
     assert test2.call_count == 0
     assert test3.call_count == 0
     assert test4.call_count == 1
+    assert test4.args == ('a', 1)
 
     state.b = 1
     assert test1.call_count == 1
     assert test2.call_count == 0
     assert test3.call_count == 0
     assert test4.call_count == 2
+    assert test4.args == ('b', 1)
 
     state.c = 1
     assert test1.call_count == 1
     assert test2.call_count == 1
+    assert test4.args == ('c', 1)
     assert test3.call_count == 1
+    assert test3.args == (None, 1)
     assert test4.call_count == 3
+    assert test4.args == ('c', 1)
 
     state.remove_callback('a', test1)
 

--- a/echo/tests/test_core.py
+++ b/echo/tests/test_core.py
@@ -389,3 +389,18 @@ def test_class_is_callback_property():
     assert state.is_callback_property('b')
     assert state.is_callback_property('c')
     assert not state.is_callback_property('d')
+
+
+def test_class_add_remove_callback_invalid():
+
+    def callback():
+        pass
+
+    state = State()
+    state.z = 'banana'
+    with pytest.raises(TypeError) as exc:
+        state.add_callback('banana', callback)
+    assert exc.value.args[0] == "attribute 'banana' is not a callback property"
+    with pytest.raises(TypeError) as exc:
+        state.remove_callback('banana', callback)
+    assert exc.value.args[0] == "attribute 'banana' is not a callback property"

--- a/echo/tests/test_list.py
+++ b/echo/tests/test_list.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
 import pytest
 from mock import MagicMock
 
@@ -52,7 +53,10 @@ def test_list_change_callback():
     assert test1.call_count == 1
     assert stub.prop1 == [3]
 
-    stub.prop1.clear()
+    if sys.version_info[0] == 2:
+        stub.prop1[:] = []
+    else:
+        stub.prop1.clear()
     assert test1.call_count == 2
     assert stub.prop1 == []
 
@@ -80,6 +84,14 @@ def test_list_change_callback():
     stub.prop1.sort()
     assert test1.call_count == 8
     assert stub.prop1 == [-1, 2]
+
+    stub.prop1[0] = 3
+    assert test1.call_count == 9
+    assert stub.prop1 == [3, 2]
+
+    stub.prop1[:] = []
+    assert test1.call_count == 10
+    assert stub.prop1 == []
 
 
 class Simple(HasCallbackProperties):

--- a/echo/tests/test_list.py
+++ b/echo/tests/test_list.py
@@ -98,6 +98,156 @@ class Simple(HasCallbackProperties):
     a = CallbackProperty()
 
 
+def test_state_in_a_list():
+
+    stub = Stub()
+
+    state1 = Simple()
+    state2 = Simple()
+    state3 = Simple()
+    state4 = Simple()
+    state5 = Simple()
+
+    # Add three of the state objects to the list in different ways
+    stub.prop1.append(state1)
+    stub.prop1.extend([state2, 3.4])
+    stub.prop1.insert(1, state3)
+    stub.prop1[3] = state4
+
+    # Check that all states except state 4 have a callback added
+    prop = getattr(Simple, 'a')
+    assert len(prop._callbacks[state1]) == 1
+    assert len(prop._callbacks[state2]) == 1
+    assert len(prop._callbacks[state3]) == 1
+    assert len(prop._callbacks[state4]) == 1
+    assert state5 not in prop._callbacks
+
+    # Add a callback to the main list
+    callback = MagicMock()
+    stub.add_callback('prop1', callback)
+
+    # Check that modifying attributes of the state objects triggers the list
+    # callback.
+    assert callback.call_count == 0
+    state1.a = 1
+    assert callback.call_count == 1
+    state2.a = 1
+    assert callback.call_count == 2
+    state3.a = 1
+    assert callback.call_count == 3
+    state4.a = 1
+    assert callback.call_count == 4
+    state5.a = 1
+    assert callback.call_count == 4
+
+    # Remove one of the state objects and try again
+    stub.prop1.pop(0)
+    assert callback.call_count == 5
+    assert len(prop._callbacks[state1]) == 0
+    assert len(prop._callbacks[state2]) == 1
+    assert len(prop._callbacks[state3]) == 1
+    assert len(prop._callbacks[state4]) == 1
+    assert state5 not in prop._callbacks
+
+    # Now modifying state1 sholdn't affect the call cont
+    state1.a = 2
+    assert callback.call_count == 5
+    state2.a = 2
+    assert callback.call_count == 6
+    state3.a = 2
+    assert callback.call_count == 7
+    state4.a = 2
+    assert callback.call_count == 8
+    state5.a = 2
+    assert callback.call_count == 8
+
+    # Remove again this time using remove
+    stub.prop1.remove(state2)
+    assert callback.call_count == 9
+    assert len(prop._callbacks[state1]) == 0
+    assert len(prop._callbacks[state2]) == 0
+    assert len(prop._callbacks[state3]) == 1
+    assert len(prop._callbacks[state4]) == 1
+    assert state5 not in prop._callbacks
+
+    # Now modifying state2 sholdn't affect the call cont
+    state1.a = 3
+    assert callback.call_count == 9
+    state2.a = 3
+    assert callback.call_count == 9
+    state3.a = 3
+    assert callback.call_count == 10
+    state4.a = 3
+    assert callback.call_count == 11
+    state5.a = 3
+    assert callback.call_count == 11
+
+    # Remove using item access
+    stub.prop1[1] = 3.3
+    assert callback.call_count == 12
+    assert len(prop._callbacks[state1]) == 0
+    assert len(prop._callbacks[state2]) == 0
+    assert len(prop._callbacks[state3]) == 1
+    assert len(prop._callbacks[state4]) == 0
+    assert state5 not in prop._callbacks
+
+    # Now modifying state4 sholdn't affect the call cont
+    state1.a = 4
+    assert callback.call_count == 12
+    state2.a = 4
+    assert callback.call_count == 12
+    state3.a = 4
+    assert callback.call_count == 13
+    state4.a = 4
+    assert callback.call_count == 13
+    state5.a = 4
+    assert callback.call_count == 13
+
+    # Now use slice access to remove state3 and add state5 in one go
+    stub.prop1[0:2] = [2.2, state5]
+    assert callback.call_count == 14
+    assert len(prop._callbacks[state1]) == 0
+    assert len(prop._callbacks[state2]) == 0
+    assert len(prop._callbacks[state3]) == 0
+    assert len(prop._callbacks[state4]) == 0
+    assert len(prop._callbacks[state5]) == 1
+
+    # Now only modifying state5 should have an effect
+    state1.a = 5
+    assert callback.call_count == 14
+    state2.a = 5
+    assert callback.call_count == 14
+    state3.a = 5
+    assert callback.call_count == 14
+    state4.a = 5
+    assert callback.call_count == 14
+    state5.a = 5
+    assert callback.call_count == 15
+
+    if sys.version_info[0] >= 3:
+
+        # On Python 3, check that clear does the right thing
+        stub.prop1.clear()
+        assert callback.call_count == 16
+        assert len(prop._callbacks[state1]) == 0
+        assert len(prop._callbacks[state2]) == 0
+        assert len(prop._callbacks[state3]) == 0
+        assert len(prop._callbacks[state4]) == 0
+        assert len(prop._callbacks[state5]) == 0
+
+        # Now the callback should never be called
+        state1.a = 6
+        assert callback.call_count == 16
+        state2.a = 6
+        assert callback.call_count == 16
+        state3.a = 6
+        assert callback.call_count == 16
+        state4.a = 6
+        assert callback.call_count == 16
+        state5.a = 6
+        assert callback.call_count == 16
+
+
 def test_nested_callbacks_in_list():
 
     stub1 = Stub()

--- a/echo/tests/test_list.py
+++ b/echo/tests/test_list.py
@@ -1,0 +1,105 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+from mock import MagicMock
+
+from echo import CallbackProperty, ListCallbackProperty, HasCallbackProperties
+
+
+class Stub(HasCallbackProperties):
+    prop1 = ListCallbackProperty()
+    prop2 = ListCallbackProperty()
+
+
+def test_list_normal_callback():
+
+    stub = Stub()
+
+    test1 = MagicMock()
+    stub.add_callback('prop1', test1)
+
+    stub.prop1 = [3]
+    assert test1.call_count == 1
+
+    stub.prop2 = [4]
+    assert test1.call_count == 1
+
+
+def test_list_invalid():
+
+    stub = Stub()
+    with pytest.raises(TypeError) as exc:
+        stub.prop1 = 'banana'
+    assert exc.value.args[0] == "callback property should be a list"
+
+
+def test_list_default():
+
+    stub = Stub()
+    stub.prop1.append(1)
+
+
+def test_list_change_callback():
+
+    stub = Stub()
+
+    test1 = MagicMock()
+    stub.add_callback('prop1', test1)
+
+    assert test1.call_count == 0
+
+    stub.prop1.append(3)
+    assert test1.call_count == 1
+    assert stub.prop1 == [3]
+
+    stub.prop1.clear()
+    assert test1.call_count == 2
+    assert stub.prop1 == []
+
+    stub.prop1.extend([1, 2, 3])
+    assert test1.call_count == 3
+    assert stub.prop1 == [1, 2, 3]
+
+    stub.prop1.insert(0, -1)
+    assert test1.call_count == 4
+    assert stub.prop1 == [-1, 1, 2, 3]
+
+    p = stub.prop1.pop()
+    assert test1.call_count == 5
+    assert p == 3
+    assert stub.prop1 == [-1, 1, 2]
+
+    stub.prop1.remove(1)
+    assert test1.call_count == 6
+    assert stub.prop1 == [-1, 2]
+
+    stub.prop1.reverse()
+    assert test1.call_count == 7
+    assert stub.prop1 == [2, -1]
+
+    stub.prop1.sort()
+    assert test1.call_count == 8
+    assert stub.prop1 == [-1, 2]
+
+
+class Simple(HasCallbackProperties):
+    a = CallbackProperty()
+
+
+def test_nested_callbacks_in_list():
+
+    stub1 = Stub()
+    stub2 = Stub()
+    simple = Simple()
+    stub1.prop1.append(stub2)
+    stub1.prop1.append(simple)
+
+    test1 = MagicMock()
+
+    stub1.add_callback('prop1', test1)
+
+    stub2.prop1.append(2)
+    assert test1.call_count == 1
+
+    simple.a = 'banana!'
+    assert test1.call_count == 2


### PR DESCRIPTION
Added a HasCallbackProperties class that can be used to add callbacks directly from a class method, including to add a callback to *all* callback properties. Also added a ListCallbackProperty class that triggers a notification if anything in the list is changed, including if the list contains a class that inherits from HasCallbackProperties which itself has properties that change.

This is a WIP - I am exploring whether this is the correct foundation for the state classes I want to implement in glue. This PR still needs docs etc. even if it does work.