### PR TITLE
Added a new class to keep two callback properties in sync

### DIFF
--- a/echo/core.py
+++ b/echo/core.py
@@ -7,7 +7,7 @@ from functools import partial
 __all__ = ['CallbackProperty', 'callback_property',
            'add_callback', 'remove_callback',
            'delay_callback', 'ignore_callback',
-           'HasCallbackProperties']
+           'HasCallbackProperties', 'keep_in_sync']
 
 
 class CallbackProperty(object):
@@ -445,3 +445,35 @@ def ignore_callback(instance, *props):
         p = getattr(type(instance), prop)
         assert isinstance(p, CallbackProperty)
         p.enable(instance)
+
+
+class keep_in_sync(object):
+
+    def __init__(self, instance1, prop1, instance2, prop2):
+
+        self.instance1 = instance1
+        self.prop1 = prop1
+
+        self.instance2 = instance2
+        self.prop2 = prop2
+
+        self._syncing = False
+
+        add_callback(self.instance1, self.prop1, self.prop2_from_prop1)
+        add_callback(self.instance2, self.prop2, self.prop1_from_prop2)
+
+    def prop1_from_prop2(self, value):
+        if not self._syncing:
+            self._syncing = True
+            setattr(self.instance1, self.prop1, getattr(self.instance2, self.prop2))
+            self._syncing = False
+
+    def prop2_from_prop1(self, value):
+        if not self._syncing:
+            self._syncing = True
+            setattr(self.instance2, self.prop2, getattr(self.instance1, self.prop1))
+            self._syncing = False
+
+    def stop_syncing(self):
+        remove_callback(self.instance1, self.prop1, self.prop2_from_prop1)
+        remove_callback(self.instance2, self.prop2, self.prop1_from_prop2)


### PR DESCRIPTION
This is a convenience function that does the hard work of setting up the callback functions and avoiding circular calls