### PR TITLE
Use weakref when adding method callbacks to avoid circular references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,13 @@
+Full changelog
+==============
+
+0.2 (unreleased)
+----------------
+
+* Ensure that when adding method callbacks, we use weak references to avoid
+  any circular references.
+
+0.1 (2014-03-13)
+----------------
+
+* Initial version

--- a/echo/callback_container.py
+++ b/echo/callback_container.py
@@ -71,4 +71,5 @@ class CallbackContainer(object):
                 if isinstance(callback, tuple) and value.__func__ is callback[0]() and value.__self__ is callback[1]():
                     self.callbacks.remove(callback)
         else:
-            self.callbacks.remove(value)
+            if value in self.callbacks:
+                self.callbacks.remove(value)

--- a/echo/callback_container.py
+++ b/echo/callback_container.py
@@ -1,0 +1,74 @@
+import weakref
+
+__all__ = ['CallbackContainer']
+
+
+class CallbackContainer(object):
+    """
+    A list of callback functions, which ...
+    """
+
+    def __init__(self):
+        self.callbacks = []
+
+    def _wrap(self, value):
+        """
+        """
+
+        # We need to be careful with storing references to methods, because
+        # if the callback method is on a class which contains both the callback
+        # and the callback property, a circular reference is created which
+        # results in a memory leak. Instead, we need to use a weak reference
+        # which results in the callback being removed if the instance is
+        # destroyed.
+
+        if not callable(value):
+            raise TypeError("Only callable values can be stored in CallbackContainer")
+
+        elif self.is_bound_method(value):
+
+            # We are dealing with a bound method. Method references aren't
+            # persistent, so instead we store a reference to the function
+            # and instance.
+
+            value = (weakref.ref(value.__func__),
+                     weakref.ref(value.__self__, self._auto_remove))
+
+        return value
+
+    def _auto_remove(self, method_instance):
+        for value in self.callbacks[:]:
+            if isinstance(value, tuple) and value[1] is method_instance:
+                self.callbacks.remove(value)
+
+    def __contains__(self, value):
+        if self.is_bound_method(value):
+            for callback in self.callbacks[:]:
+                if isinstance(callback, tuple) and value.__func__ is callback[0]() and value.__self__ is callback[1]():
+                    return True
+            else:
+                return False
+        else:
+            return value in self.callbacks
+
+    def __iter__(self):
+        for callback in self.callbacks:
+            yield callback
+
+    def __len__(self):
+        return len(self.callbacks)
+
+    @staticmethod
+    def is_bound_method(func):
+        return hasattr(func, '__func__') and getattr(func, '__self__', None) is not None
+
+    def append(self, value):
+        self.callbacks.append(self._wrap(value))
+
+    def remove(self, value):
+        if self.is_bound_method(value):
+            for callback in self.callbacks[:]:
+                if isinstance(callback, tuple) and value.__func__ is callback[0]() and value.__self__ is callback[1]():
+                    self.callbacks.remove(callback)
+        else:
+            self.callbacks.remove(value)

--- a/echo/callback_container.py
+++ b/echo/callback_container.py
@@ -1,4 +1,5 @@
 import weakref
+from functools import partial
 
 __all__ = ['CallbackContainer']
 
@@ -55,7 +56,12 @@ class CallbackContainer(object):
 
     def __iter__(self):
         for callback in self.callbacks:
-            yield callback
+            if isinstance(callback, tuple):
+                func = callback[0]()
+                inst = callback[1]()
+                yield partial(func, inst)
+            else:
+                yield callback
 
     def __len__(self):
         return len(self.callbacks)

--- a/echo/core.py
+++ b/echo/core.py
@@ -104,19 +104,9 @@ class CallbackProperty(object):
         if self._disabled.get(instance, False):
             return
         for cback in self._callbacks.get(instance, []):
-            if isinstance(cback, tuple):
-                func = cback[0]()
-                instance = cback[1]()
-                func(instance, new)
-            else:
-                cback(new)
+            cback(new)
         for cback in self._2arg_callbacks.get(instance, []):
-            if isinstance(cback, tuple):
-                func = cback[0]()
-                instance = cback[1]()
-                func(instance, old, new)
-            else:
-                cback(old, new)
+            cback(old, new)
 
     def disable(self, instance):
         """
@@ -198,12 +188,7 @@ class HasCallbackProperties(object):
 
     def notify_global(self, **kwargs):
         for callback in self._global_callbacks:
-            if isinstance(callback, tuple):
-                func = callback[0]()
-                instance = callback[1]()
-                func(instance, **kwargs)
-            else:
-                callback(**kwargs)
+            callback(**kwargs)
 
     def __setattr__(self, attribute, value):
         super(HasCallbackProperties, self).__setattr__(attribute, value)

--- a/echo/core.py
+++ b/echo/core.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from contextlib import contextmanager
 from weakref import WeakKeyDictionary
 
-from echo.callback_container import CallbackContainer
+from .callback_container import CallbackContainer
 
 __all__ = ['CallbackProperty', 'callback_property',
            'add_callback', 'remove_callback',
@@ -178,7 +178,7 @@ class HasCallbackProperties(object):
     """
 
     def __init__(self):
-        from echo.list import ListCallbackProperty
+        from .list import ListCallbackProperty
         self._global_callbacks = CallbackContainer()
         self._callback_wrappers = {}
         for prop_name, prop in self.iter_callback_properties():
@@ -186,7 +186,7 @@ class HasCallbackProperties(object):
                 prop.add_callback(self, self.notify_global_lists)
 
     def notify_global_lists(self, *args):
-        from echo.list import ListCallbackProperty
+        from .list import ListCallbackProperty
         properties = {}
         for prop_name, prop in self.iter_callback_properties():
             if isinstance(prop, ListCallbackProperty):
@@ -206,9 +206,9 @@ class HasCallbackProperties(object):
                 callback(**kwargs)
 
     def __setattr__(self, attribute, value):
+        super(HasCallbackProperties, self).__setattr__(attribute, value)
         if self.is_callback_property(attribute):
             self.notify_global(**{attribute: value})
-        super(HasCallbackProperties, self).__setattr__(attribute, value)
 
     def add_callback(self, name, callback, echo_old=False):
         """

--- a/echo/list.py
+++ b/echo/list.py
@@ -18,32 +18,32 @@ class CallbackList(list):
     def append(self, value):
         super(CallbackList, self).append(value)
         if isinstance(value, HasCallbackProperties):
-            value.add_callback('*', self.callback)
+            value.add_global_callback(self.callback)
         self.callback()
 
     def extend(self, iterable):
         super(CallbackList, self).extend(iterable)
         for item in iterable:
             if isinstance(item, HasCallbackProperties):
-                item.add_callback('*', self.callback)
+                item.add_global_callback(self.callback)
         self.callback()
 
     def insert(self, index, value):
         super(CallbackList, self).insert(index, value)
         if isinstance(value, HasCallbackProperties):
-            value.add_callback('*', self.callback)
+            value.add_global_callback(self.callback)
         self.callback()
 
     def pop(self, index=-1):
         result = super(CallbackList, self).pop(index)
         if isinstance(result, HasCallbackProperties):
-            result.remove_callback('*', self.callback)
+            result.remove_global_callback(self.callback)
         self.callback()
         return result
 
     def remove(self, value):
         if isinstance(value, HasCallbackProperties):
-            value.remove_callback('*', self.callback)
+            value.remove_global_callback(self.callback)
         super(CallbackList, self).remove(value)
         self.callback()
 
@@ -63,7 +63,7 @@ class CallbackList(list):
 
         for old_value in old_values:
             if isinstance(old_value, HasCallbackProperties):
-                old_value.remove_callback('*', self.callback)
+                old_value.remove_global_callback(self.callback)
 
         if isinstance(slc, slice):
             new_values = new_value
@@ -72,7 +72,7 @@ class CallbackList(list):
 
         for value in new_values:
             if isinstance(value, HasCallbackProperties):
-                value.add_callback('*', self.callback)
+                value.add_global_callback(self.callback)
 
         super(CallbackList, self).__setitem__(slc, new_value)
         self.callback()
@@ -82,7 +82,7 @@ class CallbackList(list):
         def clear(self):
             for item in self:
                 if isinstance(item, HasCallbackProperties):
-                    item.remove_callback('*', self.callback)
+                    item.remove_global_callback(self.callback)
             super(CallbackList, self).clear()
             self.callback()
 
@@ -96,11 +96,11 @@ class CallbackList(list):
 
             for old_value in old_values:
                 if isinstance(old_value, HasCallbackProperties):
-                    old_value.remove_callback('*', self.callback)
+                    old_value.remove_global_callback(self.callback)
 
             for value in new_values:
                 if isinstance(value, HasCallbackProperties):
-                    value.add_callback('*', self.callback)
+                    value.add_global_callback(self.callback)
 
             super(CallbackList, self).__setslice__(start, end, new_values)
             self.callback()
@@ -122,8 +122,8 @@ class ListCallbackProperty(CallbackProperty):
         if not isinstance(value, list):
             raise TypeError('callback property should be a list')
 
-        def callback(*args):
-            self.notify(instance, value, value)
+        def callback(*args, **kwargs):
+            self.notify(instance, wrapped_list, wrapped_list)
 
         wrapped_list = CallbackList(callback, value)
         super(ListCallbackProperty, self)._default_setter(instance, wrapped_list)

--- a/echo/tests/test_core.py
+++ b/echo/tests/test_core.py
@@ -299,13 +299,13 @@ def test_class_add_remove_callback():
 
     # Deliberaty adding to c twice to make sure it works fine with two callbacks
     test2 = mockclass()
-    state.add_callback('c', test2, as_kwargs=True)
+    state.add_callback('c', test2)
 
     test3 = mockclass()
     state.add_callback('c', test3, echo_old=True)
 
     test4 = mockclass()
-    state.add_callback('*', test4, as_kwargs=True)
+    state.add_global_callback(test4)
 
     state.a = 1
     assert test1.call_count == 1
@@ -361,17 +361,7 @@ def test_class_add_remove_callback():
     assert test3.call_count == 3
     assert test4.call_count == 12
 
-    state.remove_callback('a', test4)
-
-    state.a = 5
-    state.b = 5
-    state.c = 5
-    assert test1.call_count == 1
-    assert test2.call_count == 2
-    assert test3.call_count == 3
-    assert test4.call_count == 14
-
-    state.remove_callback('*', test4)
+    state.remove_global_callback(test4)
 
     state.a = 6
     state.b = 6
@@ -379,7 +369,7 @@ def test_class_add_remove_callback():
     assert test1.call_count == 1
     assert test2.call_count == 2
     assert test3.call_count == 3
-    assert test4.call_count == 14
+    assert test4.call_count == 12
 
 
 def test_class_is_callback_property():

--- a/echo/tests/test_core.py
+++ b/echo/tests/test_core.py
@@ -449,3 +449,35 @@ def test_keep_in_sync():
     assert state1_control.b is None
     assert state2.c == 7
     assert state2_control.c is None
+
+
+
+class Stub(object):
+    prop1 = CallbackProperty()
+    prop2 = CallbackProperty(5)
+    prop3 = 5
+
+
+def test_cleanup_when_objects_destroyed():
+
+    state = State()
+
+    class BasicClass():
+
+        def __init__(self, s):
+            self.s = s
+            self.s.add_callback('a', self.callback)
+            self.raise_error = False
+
+        def callback(self, arg):
+            if self.raise_error:
+                raise ValueError('Should never get here')
+
+    def isolated(state):
+        c = BasicClass(state)
+        state.a = 1
+        c.raise_error = True
+
+    isolated(state)
+
+    state.a = 2

--- a/echo/tests/test_core.py
+++ b/echo/tests/test_core.py
@@ -481,3 +481,28 @@ def test_cleanup_when_objects_destroyed():
     isolated(state)
 
     state.a = 2
+
+
+def test_cleanup_when_objects_destroyed_kwargs():
+
+    state = State()
+
+    class BasicClass():
+
+        def __init__(self, s):
+            self.s = s
+            self.s.add_global_callback(self.callback)
+            self.raise_error = False
+
+        def callback(self, **kwargs):
+            if self.raise_error:
+                raise ValueError('Should never get here')
+
+    def isolated(state):
+        c = BasicClass(state)
+        state.a = 1
+        c.raise_error = True
+
+    isolated(state)
+
+    state.a = 2

--- a/echo/tests/test_core.py
+++ b/echo/tests/test_core.py
@@ -441,13 +441,6 @@ def test_keep_in_sync():
     assert state2_control.c is None
 
 
-
-class Stub(object):
-    prop1 = CallbackProperty()
-    prop2 = CallbackProperty(5)
-    prop3 = 5
-
-
 def test_cleanup_when_objects_destroyed():
 
     state = State()

--- a/echo/tests/test_list.py
+++ b/echo/tests/test_list.py
@@ -114,13 +114,13 @@ def test_state_in_a_list():
     stub.prop1.insert(1, state3)
     stub.prop1[3] = state4
 
-    # Check that all states except state 4 have a callback added
+    # Check that all states except state 5 have a callback added
     prop = getattr(Simple, 'a')
-    assert len(prop._callbacks[state1]) == 1
-    assert len(prop._callbacks[state2]) == 1
-    assert len(prop._callbacks[state3]) == 1
-    assert len(prop._callbacks[state4]) == 1
-    assert state5 not in prop._callbacks
+    assert len(state1._global_callbacks) == 1
+    assert len(state2._global_callbacks) == 1
+    assert len(state3._global_callbacks) == 1
+    assert len(state4._global_callbacks) == 1
+    assert len(state5._global_callbacks) == 0
 
     # Add a callback to the main list
     callback = MagicMock()
@@ -143,11 +143,11 @@ def test_state_in_a_list():
     # Remove one of the state objects and try again
     stub.prop1.pop(0)
     assert callback.call_count == 5
-    assert len(prop._callbacks[state1]) == 0
-    assert len(prop._callbacks[state2]) == 1
-    assert len(prop._callbacks[state3]) == 1
-    assert len(prop._callbacks[state4]) == 1
-    assert state5 not in prop._callbacks
+    assert len(state1._global_callbacks) == 0
+    assert len(state2._global_callbacks) == 1
+    assert len(state3._global_callbacks) == 1
+    assert len(state4._global_callbacks) == 1
+    assert len(state5._global_callbacks) == 0
 
     # Now modifying state1 sholdn't affect the call cont
     state1.a = 2
@@ -164,11 +164,11 @@ def test_state_in_a_list():
     # Remove again this time using remove
     stub.prop1.remove(state2)
     assert callback.call_count == 9
-    assert len(prop._callbacks[state1]) == 0
-    assert len(prop._callbacks[state2]) == 0
-    assert len(prop._callbacks[state3]) == 1
-    assert len(prop._callbacks[state4]) == 1
-    assert state5 not in prop._callbacks
+    assert len(state1._global_callbacks) == 0
+    assert len(state2._global_callbacks) == 0
+    assert len(state3._global_callbacks) == 1
+    assert len(state4._global_callbacks) == 1
+    assert len(state5._global_callbacks) == 0
 
     # Now modifying state2 sholdn't affect the call cont
     state1.a = 3
@@ -185,11 +185,11 @@ def test_state_in_a_list():
     # Remove using item access
     stub.prop1[1] = 3.3
     assert callback.call_count == 12
-    assert len(prop._callbacks[state1]) == 0
-    assert len(prop._callbacks[state2]) == 0
-    assert len(prop._callbacks[state3]) == 1
-    assert len(prop._callbacks[state4]) == 0
-    assert state5 not in prop._callbacks
+    assert len(state1._global_callbacks) == 0
+    assert len(state2._global_callbacks) == 0
+    assert len(state3._global_callbacks) == 1
+    assert len(state4._global_callbacks) == 0
+    assert len(state5._global_callbacks) == 0
 
     # Now modifying state4 sholdn't affect the call cont
     state1.a = 4
@@ -206,11 +206,11 @@ def test_state_in_a_list():
     # Now use slice access to remove state3 and add state5 in one go
     stub.prop1[0:2] = [2.2, state5]
     assert callback.call_count == 14
-    assert len(prop._callbacks[state1]) == 0
-    assert len(prop._callbacks[state2]) == 0
-    assert len(prop._callbacks[state3]) == 0
-    assert len(prop._callbacks[state4]) == 0
-    assert len(prop._callbacks[state5]) == 1
+    assert len(state1._global_callbacks) == 0
+    assert len(state2._global_callbacks) == 0
+    assert len(state3._global_callbacks) == 0
+    assert len(state4._global_callbacks) == 0
+    assert len(state5._global_callbacks) == 1
 
     # Now only modifying state5 should have an effect
     state1.a = 5
@@ -229,11 +229,11 @@ def test_state_in_a_list():
         # On Python 3, check that clear does the right thing
         stub.prop1.clear()
         assert callback.call_count == 16
-        assert len(prop._callbacks[state1]) == 0
-        assert len(prop._callbacks[state2]) == 0
-        assert len(prop._callbacks[state3]) == 0
-        assert len(prop._callbacks[state4]) == 0
-        assert len(prop._callbacks[state5]) == 0
+        assert len(state1._global_callbacks) == 0
+        assert len(state2._global_callbacks) == 0
+        assert len(state3._global_callbacks) == 0
+        assert len(state4._global_callbacks) == 0
+        assert len(state5._global_callbacks) == 0
 
         # Now the callback should never be called
         state1.a = 6


### PR DESCRIPTION
This is still a WIP, but works. I need to remove the old way of setting global callbacks and duplicate code in the weakref stuff.