### PR TITLE
When iterating over a CallbackContainer, manually check that the weakrefs resolve

### DIFF
--- a/echo/callback_container.py
+++ b/echo/callback_container.py
@@ -71,6 +71,11 @@ class CallbackContainer(object):
             if len(callback) == 3:
                 func = callback[0]()
                 inst = callback[1]()
+                # In some cases it can happen that the instance has been
+                # garbage collected but _auto_remove hasn't been called, so we
+                # just check here that the weakrefs were resolved
+                if func is None or inst is None:
+                    continue
                 yield partial(func, inst)
             else:
                 yield callback[0]


### PR DESCRIPTION
This should avoid issues such as seen in https://github.com/glue-viz/glue-jupyter/pull/202. Ideally of course this case should never happen, but it does and this must indicate some kind of race condition where ``_auto_remove`` is not called in time.