### PR TITLE
Remove deprecated call to pkg_resources

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -44,7 +44,7 @@ jobs:
 
         # Test a few configurations on MacOS X (ask for arm64 with py310; may not be available yet)
         - macos: py38-test-pyqt514
-        - macos: py310-test-pyqt515
+        - macos: py311-test-pyqt515
           PLAT: arm64
         - macos: py310-test-pyqt63
           PLAT: arm64

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -34,20 +34,14 @@ jobs:
       envs: |
         # Standard tests
         # Linux builds - test on all supported PyQt5, PyQt6 and PySide2 versions
-        - linux: py37-test-pyqt510
-        - linux: py37-test-pyqt511
-        - linux: py37-test-pyqt512
-        - linux: py37-test-pyqt513
         - linux: py39-test-pyqt515
         - linux: py310-test-pyqt63
 
-        - linux: py37-test-pyside513
         - linux: py38-test-pyside514
         - linux: py310-test-pyside515
         - linux: py310-test-pyside63
 
         # Test a few configurations on MacOS X (ask for arm64 with py310; may not be available yet)
-        - macos: py37-test-pyqt513
         - macos: py38-test-pyqt514
         - macos: py310-test-pyqt515
           PLAT: arm64
@@ -58,7 +52,6 @@ jobs:
         - macos: py310-test-pyside63
 
         # Test some configurations on Windows
-        - windows: py37-test-pyqt510
         - windows: py38-test-pyqt514
         - windows: py39-test-pyqt515
         - windows: py310-test-pyqt63
@@ -72,7 +65,7 @@ jobs:
         - linux: py310-docs-pyqt63
           coverage: false
 
-        - macos: py37-docs-pyqt513
+        - macos: py39-docs-pyqt515
           coverage: false
 
         - windows: py38-docs-pyqt513

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -60,7 +60,7 @@ jobs:
         - windows: py310-test-pyside63
 
         # Try out documentation build on Linux, macOS and Windows
-        - linux: py39-docs-pyqt513
+        - linux: py39-docs-pyqt514
           coverage: false
         - linux: py310-docs-pyqt63
           coverage: false
@@ -68,7 +68,7 @@ jobs:
         - macos: py39-docs-pyqt515
           coverage: false
 
-        - windows: py38-docs-pyqt513
+        - windows: py38-docs-pyqt514
           coverage: false
 
   publish:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -36,6 +36,7 @@ jobs:
         # Linux builds - test on all supported PyQt5, PyQt6 and PySide2 versions
         - linux: py39-test-pyqt515
         - linux: py310-test-pyqt63
+        - linux: py311-test-pyqt514
 
         - linux: py38-test-pyside514
         - linux: py310-test-pyside515

--- a/echo/version.py
+++ b/echo/version.py
@@ -1,5 +1,10 @@
-import importlib.metadata
+import sys
+
+if sys.version_info >= (3, 9):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 __all__ = ['__version__']
 
-__version__ = importlib.metadata.version('echo')
+__version__ = importlib_metadata.version('echo')

--- a/echo/version.py
+++ b/echo/version.py
@@ -1,8 +1,5 @@
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 
 __all__ = ['__version__']
 
-try:
-    __version__ = get_distribution('echo').version
-except DistributionNotFound:
-    __version__ = 'undefined'
+__version__ = importlib.metadata.version('echo')

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: OS Independent
     Topic :: Utilities
 license = MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ setup_requires = setuptools_scm
 install_requires =
     numpy
     qtpy
+    importlib_resources>=1.3; python_version<'3.9'
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,9 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Operating System :: OS Independent
     Topic :: Utilities
 license = MIT
@@ -22,7 +23,7 @@ long_description = file: README.rst
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ docs =
     numpydoc
     sphinx-rtd-theme
 qt =
-    PyQt5>=5.9
+    PyQt5>=5.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ setup_requires = setuptools_scm
 install_requires =
     numpy
     qtpy
-    importlib_metadata; python_version<'3.8'
+    importlib_metadata; python_version<'3.9'
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Operating System :: OS Independent
@@ -23,12 +22,12 @@ long_description = file: README.rst
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     numpy
     qtpy
-    importlib_resources>=1.3; python_version<'3.9'
+    importlib_metadata; python_version<'3.8'
 
 [options.extras_require]
 test =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-{codestyle,test,docs}-{pyqt510,pyqt511,pyqt512,pyqt513,pyqt514,pyqt515,pyside513,pyside514,pyside515,pyqt63,pyside63}
+    py{37,38,39,310,311}-{codestyle,test,docs}-{pyqt510,pyqt511,pyqt512,pyqt513,pyqt514,pyqt515,pyside513,pyside514,pyside515,pyqt63,pyside63}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 


### PR DESCRIPTION
# Remove explicit calls to pkg_resources

## Description

Sort of following the process in https://github.com/glue-viz/glue/pull/2365, this updates echo to not depend on the deprecated pkg_resources API, at the cost of requiring `importlib_metadata` for older versions of Python (but glue installations will have this dependency anyway with the above-referenced change).
