### PR TITLE
Make qtpy an optional dependency

### DIFF
--- a/echo/qt/__init__.py
+++ b/echo/qt/__init__.py
@@ -1,2 +1,5 @@
-from .connect import *   # noqa
-from .autoconnect import *  # noqa
+try:
+    from .connect import *   # noqa
+    from .autoconnect import *  # noqa
+except ImportError:
+    pass

--- a/echo/qt/tests/helpers.py
+++ b/echo/qt/tests/helpers.py
@@ -5,12 +5,14 @@ __all__ = [
     "SKIP_QT_TEST"
 ]
 
+
 def package_installed(package):
     try:
         __import__(package)
         return True
     except ImportError:
         return False
+
 
 PYQT5_INSTALLED = package_installed("PyQt5")
 PYQT6_INSTALLED = package_installed("PyQt6")

--- a/echo/qt/tests/helpers.py
+++ b/echo/qt/tests/helpers.py
@@ -1,0 +1,21 @@
+__all__ = [
+    "PYQT5_INSTALLED", "PYQT6_INSTALLED",
+    "PYSIDE2_INSTALLED", "PYSIDE6_INSTALLED",
+    "QTPY_INSTALLED", "QT_INSTALLED",
+    "SKIP_QT_TEST"
+]
+
+def package_installed(package):
+    try:
+        __import__(package)
+        return True
+    except ImportError:
+        return False
+
+PYQT5_INSTALLED = package_installed("PyQt5")
+PYQT6_INSTALLED = package_installed("PyQt6")
+PYSIDE2_INSTALLED = package_installed("PySide2")
+PYSIDE6_INSTALLED = package_installed("PySide6")
+QTPY_INSTALLED = package_installed("qtpy")
+QT_INSTALLED = PYQT5_INSTALLED or PYQT6_INSTALLED or PYSIDE2_INSTALLED or PYSIDE6_INSTALLED
+SKIP_QT_TEST = not (QTPY_INSTALLED and QT_INSTALLED)

--- a/echo/qt/tests/helpers.py
+++ b/echo/qt/tests/helpers.py
@@ -7,11 +7,8 @@ __all__ = [
 
 
 def package_installed(package):
-    try:
-        __import__(package)
-        return True
-    except ImportError:
-        return False
+    from importlib.util import find_spec
+    return find_spec(package) is not None
 
 
 PYQT5_INSTALLED = package_installed("PyQt5")

--- a/echo/qt/tests/test_autoconnect.py
+++ b/echo/qt/tests/test_autoconnect.py
@@ -1,11 +1,17 @@
 from datetime import datetime
 
+import pytest
 from numpy import datetime64
+
+from echo import CallbackProperty
+from echo.qt.tests.helpers import SKIP_QT_TEST
+
+if SKIP_QT_TEST:
+    pytest.skip(allow_module_level=True)
+
 from qtpy import QtWidgets, QtGui
 from qtpy.QtCore import QDateTime, Qt
-
 from echo.qt.autoconnect import autoconnect_callbacks_to_qt
-from echo import CallbackProperty
 from echo.qt.connect import UserDataWrapper
 
 

--- a/echo/qt/tests/test_connect.py
+++ b/echo/qt/tests/test_connect.py
@@ -20,8 +20,6 @@ from echo.qt.connect import (connect_checkable_button, connect_datetime, connect
 
 def test_connect_checkable_button():
 
-
-
     class Test(object):
         a = CallbackProperty()
         b = CallbackProperty(True)

--- a/echo/qt/tests/test_connect.py
+++ b/echo/qt/tests/test_connect.py
@@ -4,10 +4,14 @@ import pytest
 from numpy import datetime64
 from unittest.mock import MagicMock
 
+from echo import CallbackProperty
+from echo.qt.tests.helpers import SKIP_QT_TEST
+
+if SKIP_QT_TEST:
+    pytest.skip(allow_module_level=True)
+
 from qtpy import QtWidgets
 from qtpy.QtCore import QDateTime, Qt
-
-from echo import CallbackProperty
 from echo.qt.connect import (connect_checkable_button, connect_datetime, connect_text,
                              connect_combo_data, connect_combo_text,
                              connect_float_text, connect_value, connect_button,
@@ -15,6 +19,8 @@ from echo.qt.connect import (connect_checkable_button, connect_datetime, connect
 
 
 def test_connect_checkable_button():
+
+
 
     class Test(object):
         a = CallbackProperty()

--- a/echo/qt/tests/test_connect_combo_selection.py
+++ b/echo/qt/tests/test_connect_combo_selection.py
@@ -1,10 +1,13 @@
 import pytest
 import numpy as np
 
-from qtpy import QtWidgets
-
 from echo.core import CallbackProperty
 from echo.selection import SelectionCallbackProperty, ChoiceSeparator
+from echo.qt.tests.helpers import SKIP_QT_TEST
+if SKIP_QT_TEST:
+    pytest.skip(allow_module_level=True)
+
+from qtpy import QtWidgets
 from echo.qt.connect import connect_combo_selection
 
 

--- a/echo/qt/tests/test_connect_list_selection.py
+++ b/echo/qt/tests/test_connect_list_selection.py
@@ -1,11 +1,14 @@
 import pytest
 import numpy as np
 
-from qtpy import QtWidgets
-from qtpy.QtCore import Qt
-
 from echo.core import CallbackProperty
 from echo.selection import SelectionCallbackProperty, ChoiceSeparator
+from echo.qt.tests.helpers import SKIP_QT_TEST
+if SKIP_QT_TEST:
+    pytest.skip(allow_module_level=True)
+
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 from echo.qt.connect import connect_list_selection
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     numpy
-    qtpy
     importlib_metadata; python_version<'3.9'
 
 [options.extras_require]
@@ -41,4 +40,5 @@ docs =
     numpydoc
     sphinx-rtd-theme
 qt =
+    qtpy
     PyQt5>=5.14

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ changedir =
     test: .tmp/{envname}
     docs: doc
 deps =
+    pyqt{510,511,512,513,514,515,63},pyside{513,514,515,63}: qtpy>=2.0
     pyqt510: PyQt5==5.10.*
     pyqt511: PyQt5==5.11.*
     pyqt512: PyQt5==5.12.*


### PR DESCRIPTION
This PR makes `qtpy` an optional dependency, and updates the testing to reflect that.

The original motivation for this change was https://github.com/glue-viz/glue-wwt/issues/111. But anything in the glue ecosystem is likely to be using echo, and with our emphasis moving towards e.g. Jupyter it would be nice to remove the `qtpy` dependency from all sorts of things that don't need it.