### PR TITLE
Add Python 3.12 envs and newer PyQt6 + PySide6 configurations to CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -33,7 +33,7 @@ jobs:
 
       envs: |
         # Standard tests
-        # Linux builds - test on all supported PyQt5, PyQt6 and PySide2 versions
+        # Linux builds - test on all supported PyQt5, PyQt6, PySide2 and PySide6 versions and without qtpy
         - linux: py39-test-pyqt515
         - linux: py310-test-pyqt63
         - linux: py311-test-pyqt514
@@ -43,6 +43,8 @@ jobs:
         - linux: py310-test-pyside515
         - linux: py310-test-pyside63
         - linux: py312-test-pyside67
+
+        - linux: py312-test
 
         # Test a few configurations on macOS (arm64 is default on macos-14)
         - macos: py38-test-pyqt514
@@ -54,6 +56,8 @@ jobs:
         - macos: py39-test-pyside515
         - macos: py310-test-pyside66
 
+        - macos: py39-test
+
         # Test some configurations on Windows
         - windows: py38-test-pyqt514
         - windows: py39-test-pyqt515
@@ -61,6 +65,8 @@ jobs:
 
         - windows: py38-test-pyside515
         - windows: py310-test-pyside65
+
+        - windows: py311-test
 
         # Try out documentation build on Linux, macOS and Windows
         - linux: py39-docs-pyqt514

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -37,33 +37,35 @@ jobs:
         - linux: py39-test-pyqt515
         - linux: py310-test-pyqt63
         - linux: py311-test-pyqt514
+        - linux: py312-test-pyqt67
 
         - linux: py38-test-pyside514
         - linux: py310-test-pyside515
         - linux: py310-test-pyside63
+        - linux: py312-test-pyside67
 
-        # Test a few configurations on MacOS X (ask for arm64 with py310; may not be available yet)
+        # Test a few configurations on macOS (arm64 is default on macos-14)
         - macos: py38-test-pyqt514
         - macos: py311-test-pyqt515
-          PLAT: arm64
+        - macos: py312-test-pyqt66
         - macos: py310-test-pyqt63
-          PLAT: arm64
+          PLAT: x64
 
         - macos: py39-test-pyside515
-        - macos: py310-test-pyside63
+        - macos: py310-test-pyside66
 
         # Test some configurations on Windows
         - windows: py38-test-pyqt514
         - windows: py39-test-pyqt515
-        # - windows: py310-test-pyqt63
+        - windows: py312-test-pyqt65
 
         - windows: py38-test-pyside515
-        - windows: py310-test-pyside63
+        - windows: py310-test-pyside65
 
         # Try out documentation build on Linux, macOS and Windows
         - linux: py39-docs-pyqt514
           coverage: false
-        - linux: py310-docs-pyqt63
+        - linux: py312-docs-pyqt67
           coverage: false
 
         - macos: py39-docs-pyqt515

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -51,7 +51,7 @@ jobs:
         - macos: py311-test-pyqt515
         - macos: py312-test-pyqt66
         - macos: py310-test-pyqt63
-          PLAT: x64
+          runs-on: macos-13
 
         - macos: py39-test-pyside515
         - macos: py310-test-pyside66

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311}-{codestyle,test,docs}-{pyqt510,pyqt511,pyqt512,pyqt513,pyqt514,pyqt515,pyside513,pyside514,pyside515,pyqt63,pyside63}
+    py{38,39,310,311,312}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyside63,pyside64,pyside65,pyside66,pyside67}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -12,18 +12,21 @@ changedir =
     test: .tmp/{envname}
     docs: doc
 deps =
-    pyqt{510,511,512,513,514,515,63},pyside{513,514,515,63}: qtpy>=2.0
-    pyqt510: PyQt5==5.10.*
-    pyqt511: PyQt5==5.11.*
-    pyqt512: PyQt5==5.12.*
-    pyqt513: PyQt5==5.13.*
+    pyqt{514,515,63,64,65,66,67},pyside{514,515,63,64,65,66,67}: qtpy>=2.0
     pyqt514: PyQt5==5.14.*
     pyqt515: PyQt5==5.15.*
-    pyside513: PySide2==5.13.*
     pyside514: PySide2==5.14.*
     pyside515: PySide2==5.15.*
     pyqt63: PyQt6==6.3.*
+    pyqt64: PyQt6==6.4.*
+    pyqt65: PyQt6==6.5.*
+    pyqt66: PyQt6==6.6.*
+    pyqt67: PyQt6==6.7.*
     pyside63: PySide6==6.3.*
+    pyside64: PySide6==6.4.*
+    pyside65: PySide6==6.5.*
+    pyside66: PySide6==6.6.*
+    pyside67: PySide6==6.7.*
 extras =
     test
     docs: docs

--- a/tox.ini
+++ b/tox.ini
@@ -18,10 +18,15 @@ deps =
     pyside514: PySide2==5.14.*
     pyside515: PySide2==5.15.*
     pyqt63: PyQt6==6.3.*
+    pyqt63: PyQt6-Qt6==6.3.*
     pyqt64: PyQt6==6.4.*
+    pyqt64: PyQt6-Qt6==6.4.*
     pyqt65: PyQt6==6.5.*
+    pyqt65: PyQt6-Qt6==6.5.*
     pyqt66: PyQt6==6.6.*
+    pyqt66: PyQt6-Qt6==6.6.*
     pyqt67: PyQt6==6.7.*
+    pyqt67: PyQt6-Qt6==6.7.*
     pyside63: PySide6==6.3.*
     pyside64: PySide6==6.4.*
     pyside65: PySide6==6.5.*


### PR DESCRIPTION
## Description
Addressing #40 and bringing in some newer Qt6 configurations up to 6.7, matching a bit closer the `glue-qt` setup; additionally following up on #38 testing without any `qtpy` in the CI as well (13 fewer tests).
This also fixes failures as in #39, due to a `QtPy6` mismatch with the latest version of `QtPy6-Qt6` installed by default.