### PR TITLE
Fix libegl1 apt installation in Ubuntu CI; add py313 and PyQt6/PySide6 6.8 

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -29,32 +29,32 @@ jobs:
         apt:
           - '^libxcb.*-dev'
           - libxkbcommon-x11-dev
-          - libegl1-mesa
+          - libegl1
 
       envs: |
         # Standard tests
         # Linux builds - test on all supported PyQt5, PyQt6, PySide2 and PySide6 versions and without qtpy
         - linux: py39-test-pyqt515
-        - linux: py310-test-pyqt63
+        - linux: py312-test-pyqt63
         - linux: py311-test-pyqt514
-        - linux: py312-test-pyqt67
+        - linux: py313-test-pyqt68
 
         - linux: py38-test-pyside514
         - linux: py310-test-pyside515
         - linux: py310-test-pyside63
-        - linux: py312-test-pyside67
+        - linux: py312-test-pyside68
 
         - linux: py312-test
 
         # Test a few configurations on macOS (arm64 is default on macos-14)
         - macos: py38-test-pyqt514
         - macos: py311-test-pyqt515
-        - macos: py312-test-pyqt66
+        - macos: py313-test-pyqt67
         - macos: py310-test-pyqt63
           runs-on: macos-13
 
         - macos: py39-test-pyside515
-        - macos: py310-test-pyside66
+        - macos: py310-test-pyside67
 
         - macos: py39-test
 
@@ -62,6 +62,7 @@ jobs:
         - windows: py38-test-pyqt514
         - windows: py39-test-pyqt515
         - windows: py312-test-pyqt65
+        - windows: py313-test-pyqt68
 
         - windows: py38-test-pyside515
         - windows: py310-test-pyside65
@@ -84,7 +85,7 @@ jobs:
     needs: tests
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
-      libraries: '^libxcb.*-dev libxkbcommon-x11-dev libgl1-mesa-glx xvfb'
+      libraries: '^libxcb.*-dev libxkbcommon-x11-dev libgl1 xvfb'
       test_extras: 'test,qt'
       test_command: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & sleep 3; DISPLAY=:99.0 pytest --pyargs echo
     secrets:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyside63,pyside64,pyside65,pyside66,pyside67}
+    py{38,39,310,311,312,313}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyqt64,pyqt65,pyqt66,pyqt67,pyqt68,pyside63,pyside64,pyside65,pyside66,pyside67,pyside68}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -12,7 +12,7 @@ changedir =
     test: .tmp/{envname}
     docs: doc
 deps =
-    pyqt{514,515,63,64,65,66,67},pyside{514,515,63,64,65,66,67}: qtpy>=2.0
+    pyqt{514,515,63,64,65,66,67,68},pyside{514,515,63,64,65,66,67,68}: qtpy>=2.0
     pyqt514: PyQt5==5.14.*
     pyqt515: PyQt5==5.15.*
     pyside514: PySide2==5.14.*
@@ -27,11 +27,14 @@ deps =
     pyqt66: PyQt6-Qt6==6.6.*
     pyqt67: PyQt6==6.7.*
     pyqt67: PyQt6-Qt6==6.7.*
+    pyqt68: PyQt6==6.8.*
+    pyqt68: PyQt6-Qt6==6.8.*
     pyside63: PySide6==6.3.*
     pyside64: PySide6==6.4.*
     pyside65: PySide6==6.5.*
     pyside66: PySide6==6.6.*
     pyside67: PySide6==6.7.*
+    pyside68: PySide6==6.8.*
 extras =
     test
     docs: docs


### PR DESCRIPTION
## Description
Some EGL packages seem to have been renamed in Ubuntu 24; trying to fix this and add some newer env versions.