### PR TITLE
Fixed bug that occurred if a callback attribute used a property which didn't exist yet

### DIFF
--- a/echo/core.py
+++ b/echo/core.py
@@ -309,7 +309,10 @@ class HasCallbackProperties(object):
     def __setattr__(self, attribute, value):
         is_callback = self.is_callback_property(attribute)
         if is_callback:
-            previous_value = getattr(self, attribute)
+            try:
+                previous_value = getattr(self, attribute)
+            except AttributeError:
+                previous_value = None
         super(HasCallbackProperties, self).__setattr__(attribute, value)
         if is_callback and value != previous_value:
             self._notify_global(**{attribute: value})


### PR DESCRIPTION
I might try and add a regression test for this