### PR TITLE
Respect priority between one- and two-argument callbacks

### DIFF
--- a/echo/callback_container.py
+++ b/echo/callback_container.py
@@ -72,8 +72,13 @@ class CallbackContainer(object):
             else:
                 return False
 
-    def __iter__(self):
-        for callback in sorted(self.callbacks, key=lambda x: x[-1], reverse=True):
+    def iterate(self, use_priority=True, with_priority=False):
+        if use_priority:
+            iterator = sorted(self.callbacks, key=lambda x: x[-1], reverse=True)
+        else:
+            iterator = self.callbacks
+
+        for callback in iterator:
             if len(callback) == 3:
                 func = callback[0]()
                 inst = callback[1]()
@@ -82,9 +87,17 @@ class CallbackContainer(object):
                 # just check here that the weakrefs were resolved
                 if func is None or inst is None:
                     continue
-                yield partial(func, inst)
+                result = partial(func, inst)
             else:
-                yield callback[0]
+                result = callback[0]
+            if with_priority:
+                yield result, callback[-1]
+            else:
+                yield result
+
+    def __iter__(self):
+        for callback in self.iterate():
+            yield callback
 
     def __len__(self):
         return len(self.callbacks)

--- a/echo/callback_container.py
+++ b/echo/callback_container.py
@@ -72,8 +72,8 @@ class CallbackContainer(object):
             else:
                 return False
 
-    def iterate(self, use_priority=True, with_priority=False):
-        if use_priority:
+    def iterator(self, sort=True, priority=False):
+        if sort:
             iterator = sorted(self.callbacks, key=lambda x: x[-1], reverse=True)
         else:
             iterator = self.callbacks
@@ -90,13 +90,13 @@ class CallbackContainer(object):
                 result = partial(func, inst)
             else:
                 result = callback[0]
-            if with_priority:
+            if priority:
                 yield result, callback[-1]
             else:
                 yield result
 
     def __iter__(self):
-        for callback in self.iterate():
+        for callback in self.iterator():
             yield callback
 
     def __len__(self):

--- a/echo/core.py
+++ b/echo/core.py
@@ -131,9 +131,9 @@ class CallbackProperty(object):
             return
         iterators = []
         if (container := self._callbacks.get(instance, None)):
-            iterators.append((cb, priority, 1) for cb, priority in container.iterate(with_priority=True, use_priority=False))
+            iterators.append((cb, priority, 1) for cb, priority in container.iterator(priority=True, sort=False))
         if (container := self._2arg_callbacks.get(instance, None)):
-            iterators.append((cb, priority, 2) for cb, priority in container.iterate(with_priority=True, use_priority=False))
+            iterators.append((cb, priority, 2) for cb, priority in container.iterator(priority=True, sort=False))
 
         for callback, _priority, args in sorted(chain(*iterators), key=lambda x: x[1], reverse=True):
             if args == 1:


### PR DESCRIPTION
This PR is my proposal to fix #51. I wanted to make sure that:
* We could sort the one- and two-argument callbacks without having to sort each callback container individually first (since that would be wasteful performance-wise)
* We don't have to repeat the logic that checks if the instance exists, creates the partial, etc, in multiple places
* We don't change the current iteration behavior

What I did is to make an `iterator` method that can take arguments to sort (via priority) or not, and whether to give the priority as part of what's yielded. The default options give the current iteration behavior. Then `__iter__` just yields off of `iterator`. This was the cleanest way I could think to do this without changing too much elsewhere.

If we like this I can add a docstring to `iterator` and add a test.