### PR TITLE
Minimize comm updates between Python and vue, and add option to log comm calls

### DIFF
--- a/doc/vue.rst
+++ b/doc/vue.rst
@@ -70,3 +70,46 @@ values are ``bool``, ``int``, ``float``, ``text``, and ``selection``::
 Only properties referenced in the template that match callback properties
 on the state object are connected. A warning is issued if the template
 references a name that does not correspond to a callback property.
+
+Debugging with comm logging
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Call :func:`enable_comm_logging` at the start of a notebook to log every
+comm message exchanged between Python and the browser frontend for all
+widgets connected via :func:`autoconnect_callbacks_to_vue` after that point.
+Messages are emitted at ``DEBUG`` level on the ``echo`` logger.
+
+.. code-block:: python
+
+    from echo.vue import enable_comm_logging, disable_comm_logging
+
+    enable_comm_logging()   # all future widgets will be logged
+    disable_comm_logging()  # stop and unpatch any instrumented widgets
+
+To see the messages, configure the ``echo`` logger. To log to the terminal:
+
+.. code-block:: python
+
+    import logging
+    logging.getLogger('echo').setLevel(logging.DEBUG)
+    logging.getLogger('echo').addHandler(logging.StreamHandler())
+
+To log to a file (useful in glue-jupyter where stdout may be swallowed):
+
+.. code-block:: python
+
+    import logging
+    handler = logging.FileHandler('/tmp/echo.log')
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    logging.getLogger('echo').setLevel(logging.DEBUG)
+    logging.getLogger('echo').addHandler(handler)
+
+Each log line is prefixed with the direction of the message:
+
+* ``[PY->VUE]`` -- state sent from Python to the browser
+* ``[VUE->PY]`` -- state received from the browser into Python
+
+This is useful for diagnosing circular update loops, where a value is set
+in Python, propagated to Vue, modified (e.g. by rounding), sent back, and
+triggers another update. Such loops show up as a rapid sequence of
+alternating ``[PY->VUE]`` / ``[VUE->PY]`` lines with the same keys.

--- a/echo/vue/__init__.py
+++ b/echo/vue/__init__.py
@@ -3,4 +3,7 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-__all__ = ['autoconnect_callbacks_to_vue']
+from ._log import enable_comm_logging, disable_comm_logging  # noqa
+
+__all__ = ['autoconnect_callbacks_to_vue',
+           'enable_comm_logging', 'disable_comm_logging']

--- a/echo/vue/_autoconnect.py
+++ b/echo/vue/_autoconnect.py
@@ -7,6 +7,7 @@ from ._connect import (connect_bool,
                        connect_float,
                        connect_text,
                        connect_choice)
+from .._log import enable_comm_logging
 
 __all__ = ['autoconnect_callbacks_to_vue', 'HANDLERS', 'TAG_TYPE_MAP']
 
@@ -233,8 +234,12 @@ def autoconnect_callbacks_to_vue(instance, widget, template=None, extras=None,
         for wtype in refs:
             refs[wtype] -= skip
 
+    enable_comm_logging(widget)
+
     connections = {}
 
+    # Create connections with initial_sync=False so traits are added
+    # without the sync tag, avoiding per-trait comm messages.
     for wtype, prop_names in refs.items():
         handler_cls = HANDLERS[wtype]
         for prop_name in prop_names:
@@ -248,7 +253,19 @@ def autoconnect_callbacks_to_vue(instance, widget, template=None, extras=None,
                 continue
             to_w, from_w = transforms.get(prop_name, (None, None))
             handler = handler_cls(instance, prop_name, widget,
-                                  to_widget=to_w, from_widget=from_w)
+                                  to_widget=to_w, from_widget=from_w,
+                                  initial_sync=False)
             connections[prop_name] = handler
+
+    # Set the initial values, enable sync, and send state once.
+    for handler in connections.values():
+        handler._from_state()
+        handler.enable_widget_sync()
+
+    if hasattr(widget, 'send_state') and connections:
+        keys = set()
+        for handler in connections.values():
+            keys.update(handler._sync_trait_names())
+        widget.send_state(key=keys)
 
     return connections

--- a/echo/vue/_autoconnect.py
+++ b/echo/vue/_autoconnect.py
@@ -7,7 +7,7 @@ from ._connect import (connect_bool,
                        connect_float,
                        connect_text,
                        connect_choice)
-from .._log import enable_comm_logging
+from ._log import _patch_widget
 
 __all__ = ['autoconnect_callbacks_to_vue', 'HANDLERS', 'TAG_TYPE_MAP']
 
@@ -234,7 +234,7 @@ def autoconnect_callbacks_to_vue(instance, widget, template=None, extras=None,
         for wtype in refs:
             refs[wtype] -= skip
 
-    enable_comm_logging(widget)
+    _patch_widget(widget)
 
     connections = {}
 

--- a/echo/vue/_autoconnect.py
+++ b/echo/vue/_autoconnect.py
@@ -257,15 +257,15 @@ def autoconnect_callbacks_to_vue(instance, widget, template=None, extras=None,
                                   initial_sync=False)
             connections[prop_name] = handler
 
-    # Set the initial values, enable sync, and send state once.
+    # Set the initial values, enable sync, and send all state in one
+    # comm message rather than one per trait.
+    sync_keys = set()
     for handler in connections.values():
         handler._from_state()
         handler.enable_widget_sync()
+        sync_keys.update(handler._sync_trait_names())
 
-    if hasattr(widget, 'send_state') and connections:
-        keys = set()
-        for handler in connections.values():
-            keys.update(handler._sync_trait_names())
-        widget.send_state(key=keys)
+    if hasattr(widget, 'send_state') and sync_keys:
+        widget.send_state(key=sync_keys)
 
     return connections

--- a/echo/vue/_autoconnect.py
+++ b/echo/vue/_autoconnect.py
@@ -7,7 +7,7 @@ from ._connect import (connect_bool,
                        connect_float,
                        connect_text,
                        connect_choice)
-from ._log import _patch_widget
+from ._log import _enable_comm_logging_if_requested
 
 __all__ = ['autoconnect_callbacks_to_vue', 'HANDLERS', 'TAG_TYPE_MAP']
 
@@ -234,7 +234,7 @@ def autoconnect_callbacks_to_vue(instance, widget, template=None, extras=None,
         for wtype in refs:
             refs[wtype] -= skip
 
-    _patch_widget(widget)
+    _enable_comm_logging_if_requested(widget)
 
     connections = {}
 

--- a/echo/vue/_connect.py
+++ b/echo/vue/_connect.py
@@ -43,11 +43,17 @@ class BaseConnection:
     _default_trait = None
 
     def __init__(self, instance, prop, widget, widget_prop=None,
-                 to_widget=None, from_widget=None):
+                 to_widget=None, from_widget=None, initial_sync=True):
         if widget_prop is None:
             widget_prop = prop
         if self._default_trait and not widget.has_trait(widget_prop):
-            widget.add_traits(**{widget_prop: self._default_trait()})
+            trait = self._default_trait()
+            if not initial_sync:
+                # Create without sync tag so add_traits doesn't send state.
+                # The caller is responsible for enabling sync later via
+                # enable_widget_sync().
+                trait.metadata.pop('sync', None)
+            widget.add_traits(**{widget_prop: trait})
         self._instance = instance
         self._prop = prop
         self._widget = widget
@@ -55,7 +61,7 @@ class BaseConnection:
         self._to_widget_transform = to_widget
         self._from_widget_transform = from_widget
         self._updating = False
-        self.connect()
+        self.connect(initial_sync=initial_sync)
 
     def _from_state(self, *args):
         if self._updating:
@@ -81,10 +87,23 @@ class BaseConnection:
             value = self._from_widget_transform(value)
         setattr(self._instance, self._prop, value)
 
-    def connect(self):
+    def connect(self, initial_sync=True):
         add_callback(self._instance, self._prop, self._from_state)
         self._widget.observe(self._from_widget, names=[self._widget_prop])
-        self._from_state()
+        if initial_sync:
+            self._from_state()
+
+    def enable_widget_sync(self):
+        """Tag the widget trait(s) as sync=True and register in widget.keys."""
+        for name in self._sync_trait_names():
+            trait = self._widget.traits()[name]
+            if 'sync' not in trait.metadata:
+                trait.tag(sync=True)
+                if hasattr(self._widget, 'keys'):
+                    self._widget.keys.append(name)
+
+    def _sync_trait_names(self):
+        return [self._widget_prop]
 
     def disconnect(self):
         remove_callback(self._instance, self._prop, self._from_state)
@@ -156,15 +175,22 @@ class connect_choice(BaseConnection):
         if widget_prop is None:
             widget_prop = f'{prop}_selected'
         items_prop = widget_prop.replace('_selected', '_items')
+        initial_sync = kwargs.get('initial_sync', True)
         traits = {}
         if not widget.has_trait(widget_prop):
-            traits[widget_prop] = traitlets.Int(allow_none=True).tag(sync=True)
+            trait = traitlets.Int(allow_none=True)
+            if initial_sync:
+                trait.tag(sync=True)
+            traits[widget_prop] = trait
         if not widget.has_trait(items_prop):
-            traits[items_prop] = traitlets.List().tag(sync=True)
+            trait = traitlets.List()
+            if initial_sync:
+                trait.tag(sync=True)
+            traits[items_prop] = trait
         if traits:
             widget.add_traits(**traits)
         self._items_prop = items_prop
-        super().__init__(instance, prop, widget, widget_prop)
+        super().__init__(instance, prop, widget, widget_prop, **kwargs)
 
     def _get_choices(self):
         prop_descriptor = getattr(type(self._instance), self._prop)
@@ -192,6 +218,9 @@ class connect_choice(BaseConnection):
                 setattr(self._widget, self._widget_prop, None)
         finally:
             self._updating = False
+
+    def _sync_trait_names(self):
+        return [self._widget_prop, self._items_prop]
 
     def update_widget(self, value):  # pragma: no cover
         pass  # Handled by _from_state

--- a/echo/vue/_connect.py
+++ b/echo/vue/_connect.py
@@ -49,9 +49,8 @@ class BaseConnection:
         if self._default_trait and not widget.has_trait(widget_prop):
             trait = self._default_trait()
             if not initial_sync:
-                # Create without sync tag so add_traits doesn't send state.
-                # The caller is responsible for enabling sync later via
-                # enable_widget_sync().
+                # Omit sync tag so add_traits doesn't send state;
+                # enable_widget_sync() must be called later.
                 trait.metadata.pop('sync', None)
             widget.add_traits(**{widget_prop: trait})
         self._instance = instance
@@ -171,11 +170,11 @@ class connect_choice(BaseConnection):
     ``{prop}_items`` (List) and ``{prop}_selected`` (Int).
     """
 
-    def __init__(self, instance, prop, widget, widget_prop=None, **kwargs):
+    def __init__(self, instance, prop, widget, widget_prop=None,
+                 initial_sync=True, **kwargs):
         if widget_prop is None:
             widget_prop = f'{prop}_selected'
         items_prop = widget_prop.replace('_selected', '_items')
-        initial_sync = kwargs.get('initial_sync', True)
         traits = {}
         if not widget.has_trait(widget_prop):
             trait = traitlets.Int(allow_none=True)
@@ -190,7 +189,8 @@ class connect_choice(BaseConnection):
         if traits:
             widget.add_traits(**traits)
         self._items_prop = items_prop
-        super().__init__(instance, prop, widget, widget_prop, **kwargs)
+        super().__init__(instance, prop, widget, widget_prop,
+                         initial_sync=initial_sync, **kwargs)
 
     def _get_choices(self):
         prop_descriptor = getattr(type(self._instance), self._prop)

--- a/echo/vue/_log.py
+++ b/echo/vue/_log.py
@@ -42,7 +42,7 @@ def disable_comm_logging():
         widget.set_state = original_set_state
 
 
-def _patch_widget(widget):
+def _enable_comm_logging_if_requested(widget):
     """Patch a single widget if comm logging is enabled and not already patched."""
     if not _comm_logging_enabled:
         return

--- a/echo/vue/_log.py
+++ b/echo/vue/_log.py
@@ -1,0 +1,72 @@
+import logging
+
+logger = logging.getLogger('echo')
+
+# Global flag: when True, new widgets are automatically instrumented
+_comm_logging_enabled = False
+
+# Maps widget id -> (original_send, original_set_state)
+_patched_widgets = {}
+
+
+def _short_repr(obj, limit=120):
+    """Short repr that truncates long strings."""
+    s = repr(obj)
+    if len(s) > limit:
+        return s[:limit] + '...'
+    return s
+
+
+def enable_comm_logging():
+    """
+    Enable logging of comm messages (state updates) between Python and the
+    browser frontend for all widgets connected via
+    :func:`~echo.vue.autoconnect_callbacks_to_vue` after this call.
+
+    Messages are emitted at ``DEBUG`` level on the ``echo`` logger.
+    """
+    global _comm_logging_enabled
+    _comm_logging_enabled = True
+
+
+def disable_comm_logging():
+    """
+    Disable comm logging. Widgets already instrumented are unpatched, and
+    future widgets will not be instrumented.
+    """
+    global _comm_logging_enabled
+    _comm_logging_enabled = False
+    for widget_id in list(_patched_widgets):
+        original_send, original_set_state, widget = _patched_widgets.pop(widget_id)
+        widget._send = original_send
+        widget.set_state = original_set_state
+
+
+def _patch_widget(widget):
+    """Patch a single widget if comm logging is enabled and not already patched."""
+    if not _comm_logging_enabled:
+        return
+    widget_id = id(widget)
+    if widget_id in _patched_widgets:
+        return
+    if not hasattr(widget, '_send') or not hasattr(widget, 'set_state'):
+        return
+
+    original_send = widget._send
+    original_set_state = widget.set_state
+    _patched_widgets[widget_id] = (original_send, original_set_state, widget)
+
+    label = type(widget).__name__
+
+    def _logged_send(msg, buffers=None):
+        if msg.get('method') == 'update':
+            state = msg.get('state', {})
+            logger.debug('[PY->VUE] %s: %s', label, _short_repr(state))
+        return original_send(msg, buffers=buffers)
+
+    def _logged_set_state(sync_data):
+        logger.debug('[VUE->PY] %s: %s', label, _short_repr(sync_data))
+        return original_set_state(sync_data)
+
+    widget._send = _logged_send
+    widget.set_state = _logged_set_state

--- a/echo/vue/_log.py
+++ b/echo/vue/_log.py
@@ -5,7 +5,7 @@ logger = logging.getLogger('echo')
 # Global flag: when True, new widgets are automatically instrumented
 _comm_logging_enabled = False
 
-# Maps widget id -> (original_send, original_set_state)
+# Maps widget id -> (original_send, original_set_state, widget)
 _patched_widgets = {}
 
 

--- a/echo/vue/_log.py
+++ b/echo/vue/_log.py
@@ -9,14 +9,6 @@ _comm_logging_enabled = False
 _patched_widgets = {}
 
 
-def _short_repr(obj, limit=120):
-    """Short repr that truncates long strings."""
-    s = repr(obj)
-    if len(s) > limit:
-        return s[:limit] + '...'
-    return s
-
-
 def enable_comm_logging():
     """
     Enable logging of comm messages (state updates) between Python and the
@@ -61,11 +53,11 @@ def _enable_comm_logging_if_requested(widget):
     def _logged_send(msg, buffers=None):
         if msg.get('method') == 'update':
             state = msg.get('state', {})
-            logger.debug('[PY->VUE] %s: %s', label, _short_repr(state))
+            logger.debug('[PY->VUE] %s: %s', label, repr(state))
         return original_send(msg, buffers=buffers)
 
     def _logged_set_state(sync_data):
-        logger.debug('[VUE->PY] %s: %s', label, _short_repr(sync_data))
+        logger.debug('[VUE->PY] %s: %s', label, repr(sync_data))
         return original_set_state(sync_data)
 
     widget._send = _logged_send

--- a/echo/vue/tests/test_log.py
+++ b/echo/vue/tests/test_log.py
@@ -1,0 +1,93 @@
+import logging
+
+import pytest
+
+traitlets = pytest.importorskip("traitlets")
+
+from echo import CallbackProperty, HasCallbackProperties  # noqa: E402
+from echo.vue._autoconnect import autoconnect_callbacks_to_vue  # noqa: E402
+from echo.vue._log import enable_comm_logging, disable_comm_logging  # noqa: E402
+
+TEMPLATE = """
+<template>
+    <v-slider :value.sync="x_min" />
+</template>
+"""
+
+
+class State(HasCallbackProperties):
+    x_min = CallbackProperty(0.0)
+
+
+class Widget(traitlets.HasTraits):
+    """Minimal stand-in for an ipywidget that calls _send on trait changes."""
+
+    def _send(self, msg, buffers=None):
+        pass
+
+    def set_state(self, sync_data):
+        for k, v in sync_data.items():
+            setattr(self, k, v)
+
+    def _notify_trait(self, name, old_value, new_value):
+        super()._notify_trait(name, old_value, new_value)
+        trait = self.traits().get(name)
+        if trait and trait.metadata.get('sync'):
+            self._send({'method': 'update', 'state': {name: new_value}})
+
+
+@pytest.fixture(autouse=True)
+def _clean_logging_state():
+    disable_comm_logging()
+    yield
+    disable_comm_logging()
+
+
+@pytest.fixture
+def connected_pair():
+    state = State()
+    widget = Widget()
+    autoconnect_callbacks_to_vue(state, widget, template=TEMPLATE)
+    return state, widget
+
+
+@pytest.fixture
+def logged_pair():
+    enable_comm_logging()
+    state = State()
+    widget = Widget()
+    autoconnect_callbacks_to_vue(state, widget, template=TEMPLATE)
+    return state, widget
+
+
+def test_logging_captures_state_to_widget(caplog, logged_pair):
+    state, widget = logged_pair
+    with caplog.at_level(logging.DEBUG, logger='echo'):
+        state.x_min = 5.0
+    assert any('[PY->VUE]' in r.message for r in caplog.records)
+
+
+def test_logging_captures_widget_to_state(caplog, logged_pair):
+    state, widget = logged_pair
+    with caplog.at_level(logging.DEBUG, logger='echo'):
+        widget.set_state({'x_min': 3.0})
+    assert any('[VUE->PY]' in r.message for r in caplog.records)
+
+
+def test_no_logging_when_disabled(caplog, connected_pair):
+    state, widget = connected_pair
+    with caplog.at_level(logging.DEBUG, logger='echo'):
+        state.x_min = 5.0
+        widget.set_state({'x_min': 3.0})
+    assert not any('[PY->VUE]' in r.message or '[VUE->PY]' in r.message
+                   for r in caplog.records)
+
+
+def test_disable_stops_logging(caplog, logged_pair):
+    state, widget = logged_pair
+    disable_comm_logging()
+    with caplog.at_level(logging.DEBUG, logger='echo'):
+        state.x_min = 5.0
+        widget.set_state({'x_min': 3.0})
+    assert not any('[PY->VUE]' in r.message or '[VUE->PY]' in r.message
+                   for r in caplog.records)


### PR DESCRIPTION
This does some work to ensure that when a widget is set up with automatically generated traits, only a single comm message is sent to the frontend instead of one per callback property.

In addition, I've added some logging which can be enabled to see comm messages between python and vue for the automatically created widgets (disabled by default)