### PR TITLE
Add list, dict, and any connection types to echo.vue autoconnect

### DIFF
--- a/doc/vue.rst
+++ b/doc/vue.rst
@@ -95,8 +95,10 @@ not automatically inferred from standard Vuetify tags:
                                  extras={'items': 'list', 'settings': 'dict'})
 
 Mutations to the containers (e.g. ``state.items.append(...)`` or
-``state.settings['visible'] = False``) are automatically synced to
-the widget. In the reverse direction (widget → state), the existing
+``state.settings['visible'] = False``) are synced to the widget.
+Each mutation triggers a full sync of the container, so use
+``delay_callback`` to batch several mutations into a single sync.
+In the reverse direction (widget → state), the existing
 ``CallbackList`` / ``CallbackDict`` objects are updated in place so
 that any attached callbacks are preserved.
 

--- a/doc/vue.rst
+++ b/doc/vue.rst
@@ -123,7 +123,7 @@ object and infers the connection type from the property descriptor:
 * ``DictCallbackProperty`` → ``dict``
 * ``SelectionCallbackProperty`` → ``selection``
 * All other ``CallbackProperty`` → ``any`` (uses ``traitlets.Any``,
-  no type coercion — equivalent to what ``GlueState`` provided)
+  no type coercion)
 
 You can still use ``extras`` to override specific properties with
 custom transforms, and ``skip`` to exclude properties.

--- a/doc/vue.rst
+++ b/doc/vue.rst
@@ -62,14 +62,88 @@ The connection type is inferred from the Vue component tag:
 * ``v-select``, ``v-combobox``, ``v-autocomplete`` -- selection property
 
 For custom components not in the default mapping, use the ``echo-type``
-attribute to specify the connection type. The supported ``echo-type``
-values are ``bool``, ``int``, ``float``, ``text``, and ``selection``::
+attribute to specify the connection type::
 
     <glue-float-field :value.sync="x_min" echo-type="float" />
+
+The supported ``echo-type`` values are: ``bool``, ``int``, ``float``,
+``text``, ``selection``, ``list``, ``dict``, and ``any``.
 
 Only properties referenced in the template that match callback properties
 on the state object are connected. A warning is issued if the template
 references a name that does not correspond to a callback property.
+
+Connecting list and dict properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``ListCallbackProperty`` and ``DictCallbackProperty`` can be connected
+to Vue using the ``list`` and ``dict`` types. These are typically
+specified via the ``extras`` parameter since list/dict bindings are
+not automatically inferred from standard Vuetify tags:
+
+.. code-block:: python
+
+    from echo import ListCallbackProperty, DictCallbackProperty
+
+    class AppState:
+        items = ListCallbackProperty([{'name': 'a'}])
+        settings = DictCallbackProperty({'visible': True})
+
+    state = AppState()
+    widget = MyWidget()
+    autoconnect_callbacks_to_vue(state, widget,
+                                 extras={'items': 'list', 'settings': 'dict'})
+
+Mutations to the containers (e.g. ``state.items.append(...)`` or
+``state.settings['visible'] = False``) are automatically synced to
+the widget. In the reverse direction (widget → state), the existing
+``CallbackList`` / ``CallbackDict`` objects are updated in place so
+that any attached callbacks are preserved.
+
+Discovering properties from Python
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, ``autoconnect_callbacks_to_vue`` discovers which
+properties to connect by parsing the Vue template. For state objects
+whose properties may not all appear in the template (e.g. an
+application-level state used across many components), you can instead
+discover properties directly from the Python class:
+
+.. code-block:: python
+
+    autoconnect_callbacks_to_vue(state, widget,
+                                 infer_properties_from='python')
+
+This discovers all ``CallbackProperty`` attributes on the state
+object and infers the connection type from the property descriptor:
+
+* ``ListCallbackProperty`` → ``list``
+* ``DictCallbackProperty`` → ``dict``
+* ``SelectionCallbackProperty`` → ``selection``
+* All other ``CallbackProperty`` → ``any`` (uses ``traitlets.Any``,
+  no type coercion — equivalent to what ``GlueState`` provided)
+
+You can still use ``extras`` to override specific properties with
+custom transforms, and ``skip`` to exclude properties.
+
+Connecting a subset of properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``only`` parameter accepts a set of property names (types are
+auto-inferred) or a dict (with explicit type strings or transform
+tuples). When ``only`` is provided, no template parsing or property
+discovery takes place — only the listed properties are connected:
+
+.. code-block:: python
+
+    # Auto-infer types from descriptors:
+    autoconnect_callbacks_to_vue(viewer_state, widget,
+                                 only={'x_min', 'x_max', 'x_log'})
+
+    # Explicit types / transforms:
+    autoconnect_callbacks_to_vue(viewer_state, widget,
+                                 only={'x_min': 'float',
+                                       'cmap': ('text', cmap_to_name, name_to_cmap)})
 
 Debugging with comm logging
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/echo/vue/_autoconnect.py
+++ b/echo/vue/_autoconnect.py
@@ -2,11 +2,17 @@ import os
 import warnings
 from html.parser import HTMLParser
 
+from ..containers import ListCallbackProperty, DictCallbackProperty
+from ..selection import SelectionCallbackProperty
+
 from ._connect import (connect_bool,
                        connect_int,
                        connect_float,
                        connect_text,
-                       connect_choice)
+                       connect_choice,
+                       connect_list,
+                       connect_dict,
+                       connect_any)
 from ._log import _enable_comm_logging_if_requested
 
 __all__ = ['autoconnect_callbacks_to_vue', 'HANDLERS', 'TAG_TYPE_MAP']
@@ -17,6 +23,9 @@ HANDLERS = {
     'float': connect_float,
     'text': connect_text,
     'selection': connect_choice,
+    'list': connect_list,
+    'dict': connect_dict,
+    'any': connect_any,
 }
 
 TAG_TYPE_MAP = {
@@ -126,6 +135,28 @@ def _resolve_template(widget):
     return None
 
 
+def _infer_type(instance, prop_name):
+    """Infer the connection type from the callback property descriptor."""
+    prop = getattr(type(instance), prop_name)
+    if isinstance(prop, SelectionCallbackProperty):
+        return 'selection'
+    if isinstance(prop, ListCallbackProperty):
+        return 'list'
+    if isinstance(prop, DictCallbackProperty):
+        return 'dict'
+    return 'any'
+
+
+def _discover_properties(instance):
+    """Return a refs dict for all callback properties on instance."""
+    refs = {}
+    for name in dir(instance):
+        if not name.startswith('_') and instance.is_callback_property(name):
+            wtype = _infer_type(instance, name)
+            refs.setdefault(wtype, set()).add(name)
+    return refs
+
+
 def _parse_extras(extras):
     """Parse an extras/only dict into refs and transforms."""
     refs = {}
@@ -149,22 +180,11 @@ def _parse_extras(extras):
 
 
 def autoconnect_callbacks_to_vue(instance, widget, template=None, extras=None,
-                                 only=None, skip=None):
+                                 only=None, skip=None,
+                                 infer_properties_from='vue'):
     """
     Connect callback properties on ``instance`` to traitlets on
-    ``widget`` bidirectionally, based on the Vue template.
-
-    The connection type is inferred from the Vue tag name:
-
-    * ``v-switch``, ``v-checkbox`` -- ``bool``
-    * ``v-text-field`` -- ``text`` (or ``int`` when ``type="number"``)
-    * ``v-slider``, ``v-range-slider`` -- ``float``
-    * ``v-select``, ``v-combobox``, ``v-autocomplete`` -- ``selection``
-
-    For tags not in the default mapping (e.g. custom components), add an
-    ``echo-type`` attribute to specify the connection type::
-
-        <glue-float-field :value.sync="x_min" echo-type="value" />
+    ``widget`` bidirectionally.
 
     Parameters
     ----------
@@ -172,32 +192,42 @@ def autoconnect_callbacks_to_vue(instance, widget, template=None, extras=None,
         The state object with callback properties.
     widget : HasTraits
         The ipyvuetify widget.
+    infer_properties_from : ``'vue'`` or ``'python'``
+        How to discover which properties to connect:
+
+        * ``'vue'`` (default): parse the Vue template to find
+          ``v-model`` / ``:value.sync`` bindings and infer types from
+          the Vue tags (e.g. ``v-switch`` → bool, ``v-slider`` →
+          float). Use ``extras`` for properties the parser cannot
+          discover.
+        * ``'python'``: discover all callback properties on
+          ``instance`` and infer types from the property descriptors
+          (``ListCallbackProperty`` → list, ``DictCallbackProperty``
+          → dict, ``SelectionCallbackProperty`` → selection,
+          others → any).
+
     template : str, optional
-        The Vue template string. If not provided, the template is
-        resolved from the widget's ``template_file`` class attribute or
-        ``template`` traitlet.
+        The Vue template string. Only used when
+        ``infer_properties_from='vue'``. If not provided, the
+        template is resolved from the widget's ``template_file``
+        class attribute or ``template`` traitlet.
     extras : dict, optional
-        Additional properties to connect that are not discovered from
-        the template (e.g. properties only referenced in ``v-if`` or
-        JavaScript). Values can be:
+        Additional properties to connect that are not discovered
+        automatically. Values can be:
 
-        * A type string: ``'bool'``, ``'int'``, ``'float'``, ``'text'``, or
-          ``'selection'``.
+        * A type string: ``'bool'``, ``'int'``, ``'float'``,
+          ``'text'``, ``'selection'``, ``'list'``, ``'dict'``, or
+          ``'any'``.
         * A tuple of ``(type, to_widget, from_widget)`` to supply
-          custom transforms. ``to_widget`` converts the state value
-          before setting the traitlet; ``from_widget`` converts the
-          traitlet value before setting the state property.
+          custom transforms.
 
-    only : dict, optional
-        When provided, skip template parsing and connect *only* the
-        listed properties. Same value format as ``extras``. Useful
-        for connecting properties from a secondary state object
-        without re-parsing the template.
+    only : set or dict, optional
+        When provided, connect *only* the listed properties (skip
+        automatic discovery). Can be a set of property names (types
+        auto-inferred) or a dict with the same value format as
+        ``extras``.
     skip : set, optional
-        Property names to ignore during template parsing (no warning,
-        no connection). Useful when a property found in the template
-        is handled by a separate ``autoconnect_callbacks_to_vue`` call
-        on a different state object.
+        Property names to skip (no warning, no connection).
 
     Returns
     -------
@@ -205,7 +235,25 @@ def autoconnect_callbacks_to_vue(instance, widget, template=None, extras=None,
         Mapping of property names to connection handler objects.
     """
     if only is not None:
-        refs, transforms = _parse_extras(only)
+        if isinstance(only, set):
+            refs = {}
+            transforms = {}
+            for prop_name in only:
+                wtype = _infer_type(instance, prop_name)
+                refs.setdefault(wtype, set()).add(prop_name)
+        else:
+            refs, transforms = _parse_extras(only)
+    elif infer_properties_from == 'python':
+        refs = _discover_properties(instance)
+        transforms = {}
+
+        if extras:
+            extra_refs, transforms = _parse_extras(extras)
+            extra_props = {p for names in extra_refs.values() for p in names}
+            for wtype in refs:
+                refs[wtype] -= extra_props
+            for wtype, prop_names in extra_refs.items():
+                refs.setdefault(wtype, set()).update(prop_names)
     else:
         if template is None:
             template = _resolve_template(widget)

--- a/echo/vue/_connect.py
+++ b/echo/vue/_connect.py
@@ -6,11 +6,13 @@
 
 import traitlets
 
+from ..containers import CallbackList, CallbackDict
 from ..core import add_callback, remove_callback
 from ..selection import ChoiceSeparator
 
 __all__ = ['connect_bool', 'connect_int', 'connect_float',
-           'connect_text', 'connect_choice', 'BaseConnection']
+           'connect_text', 'connect_choice', 'connect_list',
+           'connect_dict', 'connect_any', 'BaseConnection']
 
 
 class BaseConnection:
@@ -231,3 +233,107 @@ class connect_choice(BaseConnection):
         choices, _ = self._get_choices()
         if 0 <= index < len(choices):
             setattr(self._instance, self._prop, choices[index])
+
+
+def _to_plain(value):
+    """Recursively convert CallbackList/CallbackDict to plain Python types."""
+    if isinstance(value, dict):
+        return {k: _to_plain(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [_to_plain(v) for v in value]
+    return value
+
+
+def _update_list_in_place(callback_list, new_values):
+    """Update a CallbackList in place from a plain list."""
+    for i in range(min(len(callback_list), len(new_values))):
+        old_item = callback_list[i]
+        new_item = new_values[i]
+        if isinstance(old_item, dict) and isinstance(new_item, dict):
+            _update_dict_in_place(old_item, new_item)
+        elif isinstance(old_item, list) and isinstance(new_item, list):
+            _update_list_in_place(old_item, new_item)
+        elif old_item != new_item:
+            callback_list[i] = new_item
+    while len(callback_list) > len(new_values):
+        callback_list.pop()
+    for i in range(len(callback_list), len(new_values)):
+        callback_list.append(new_values[i])
+
+
+def _update_dict_in_place(callback_dict, new_values):
+    """Update a CallbackDict in place from a plain dict."""
+    for key, value in new_values.items():
+        if key in callback_dict:
+            old_value = callback_dict[key]
+            if isinstance(old_value, dict) and isinstance(value, dict):
+                _update_dict_in_place(old_value, value)
+            elif isinstance(old_value, list) and isinstance(value, list):
+                _update_list_in_place(old_value, value)
+            elif old_value != value:
+                callback_dict[key] = value
+        else:
+            callback_dict[key] = value
+    for key in set(callback_dict) - set(new_values):
+        callback_dict.pop(key)
+
+
+class connect_list(BaseConnection):
+    """Connect a ListCallbackProperty or list-valued CallbackProperty to a List traitlet."""
+
+    _default_trait = staticmethod(lambda: traitlets.List().tag(sync=True))
+
+    def update_widget(self, value):
+        if self._to_widget_transform is not None:
+            value = self._to_widget_transform(value)
+        else:
+            value = _to_plain(value) if value is not None else []
+        setattr(self._widget, self._widget_prop, value)
+
+    def update_prop(self, value):
+        if self._from_widget_transform is not None:
+            value = self._from_widget_transform(value)
+            setattr(self._instance, self._prop, value)
+        else:
+            container = getattr(self._instance, self._prop)
+            if isinstance(container, CallbackList):
+                _update_list_in_place(container, value)
+            else:
+                setattr(self._instance, self._prop, list(value))
+
+
+class connect_dict(BaseConnection):
+    """Connect a DictCallbackProperty or dict-valued CallbackProperty to a Dict traitlet."""
+
+    _default_trait = staticmethod(lambda: traitlets.Dict().tag(sync=True))
+
+    def update_widget(self, value):
+        if self._to_widget_transform is not None:
+            value = self._to_widget_transform(value)
+        else:
+            value = _to_plain(value) if value is not None else {}
+        setattr(self._widget, self._widget_prop, value)
+
+    def update_prop(self, value):
+        if self._from_widget_transform is not None:
+            value = self._from_widget_transform(value)
+            setattr(self._instance, self._prop, value)
+        else:
+            container = getattr(self._instance, self._prop)
+            if isinstance(container, CallbackDict):
+                _update_dict_in_place(container, value)
+            else:
+                setattr(self._instance, self._prop, dict(value))
+
+
+class connect_any(BaseConnection):
+    """Connect a CallbackProperty to an Any traitlet (no type coercion)."""
+
+    _default_trait = staticmethod(lambda: traitlets.Any().tag(sync=True))
+
+    def update_widget(self, value):
+        if self._to_widget_transform is not None:
+            value = self._to_widget_transform(value)
+        else:
+            value = _to_plain(value)
+        setattr(self._widget, self._widget_prop, value)

--- a/echo/vue/tests/test_autoconnect.py
+++ b/echo/vue/tests/test_autoconnect.py
@@ -3,6 +3,7 @@ import pytest
 traitlets = pytest.importorskip("traitlets")
 
 from echo import CallbackProperty, SelectionCallbackProperty, HasCallbackProperties  # noqa: E402
+from echo import ListCallbackProperty, DictCallbackProperty  # noqa: E402
 from echo.vue._autoconnect import autoconnect_callbacks_to_vue, _parse_template, _resolve_template  # noqa: E402
 
 
@@ -412,3 +413,282 @@ def test_only_with_transforms():
     assert widget.x_min == '-10.0'
     widget.x_min = '7.5'
     assert state.x_min == 7.5
+
+
+# --- List and Dict connection tests ---
+
+class ContainerState(HasCallbackProperties):
+    items = ListCallbackProperty([{'name': 'a'}, {'name': 'b'}])
+    settings = DictCallbackProperty({'visible': True, 'nested': {'x': 1, 'y': 2}})
+    tags = ListCallbackProperty(['red', 'green'])
+
+
+def test_list_state_to_widget():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'items': 'list'})
+    assert widget.items == [{'name': 'a'}, {'name': 'b'}]
+
+
+def test_list_state_mutation_syncs():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'items': 'list'})
+    state.items.append({'name': 'c'})
+    assert len(widget.items) == 3
+    assert widget.items[2] == {'name': 'c'}
+
+
+def test_list_widget_to_state():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'items': 'list'})
+    widget.items = [{'name': 'x'}]
+    assert len(state.items) == 1
+    assert state.items[0] == {'name': 'x'}
+
+
+def test_list_widget_updates_in_place():
+    """Widget changes update the existing CallbackList rather than replacing it."""
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'items': 'list'})
+    original_list = state.items
+    widget.items = [{'name': 'x'}, {'name': 'y'}]
+    assert state.items is original_list
+
+
+def test_list_simple_values():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'tags': 'list'})
+    assert widget.tags == ['red', 'green']
+    state.tags.append('blue')
+    assert widget.tags == ['red', 'green', 'blue']
+    widget.tags = ['one']
+    assert list(state.tags) == ['one']
+
+
+def test_dict_state_to_widget():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'settings': 'dict'})
+    assert widget.settings == {'visible': True, 'nested': {'x': 1, 'y': 2}}
+
+
+def test_dict_state_mutation_syncs():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'settings': 'dict'})
+    state.settings['visible'] = False
+    assert widget.settings['visible'] is False
+
+
+def test_dict_nested_mutation_syncs():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'settings': 'dict'})
+    state.settings['nested']['x'] = 99
+    assert widget.settings['nested']['x'] == 99
+
+
+def test_dict_widget_to_state():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'settings': 'dict'})
+    widget.settings = {'visible': False, 'nested': {'x': 5, 'y': 6}}
+    assert state.settings['visible'] is False
+    assert state.settings['nested']['x'] == 5
+
+
+def test_dict_widget_updates_in_place():
+    """Widget changes update the existing CallbackDict rather than replacing it."""
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'settings': 'dict'})
+    original_dict = state.settings
+    original_nested = state.settings['nested']
+    widget.settings = {'visible': False, 'nested': {'x': 5, 'y': 6}}
+    assert state.settings is original_dict
+    assert state.settings['nested'] is original_nested
+
+
+def test_dict_widget_adds_new_keys():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'settings': 'dict'})
+    widget.settings = {'visible': True, 'nested': {'x': 1, 'y': 2}, 'new_key': 'hello'}
+    assert state.settings['new_key'] == 'hello'
+
+
+def test_dict_widget_removes_keys():
+    state = ContainerState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'settings': 'dict'})
+    widget.settings = {'visible': True}
+    assert 'nested' not in state.settings
+
+
+def test_list_plain_callback_property():
+    """connect_list works with a regular CallbackProperty holding a plain list."""
+
+    class PlainListState(HasCallbackProperties):
+        open_panels = CallbackProperty([])
+
+    state = PlainListState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'open_panels': 'list'})
+
+    assert widget.open_panels == []
+    state.open_panels = [0, 2]
+    assert widget.open_panels == [0, 2]
+    # Widget→state does full replacement (not in-place) for plain lists
+    widget.open_panels = [1, 3]
+    assert state.open_panels == [1, 3]
+
+
+def test_list_and_dict_via_extras():
+    template = '<template><v-switch v-model="flag" /></template>'
+
+    class MixedState(HasCallbackProperties):
+        flag = CallbackProperty(True)
+        items = ListCallbackProperty([1, 2, 3])
+        config = DictCallbackProperty({'a': 1})
+
+    state = MixedState()
+    widget = SimpleWidget()
+    handlers = autoconnect_callbacks_to_vue(
+        state, widget, template=template,
+        extras={'items': 'list', 'config': 'dict'},
+    )
+    assert 'flag' in handlers
+    assert 'items' in handlers
+    assert 'config' in handlers
+    assert widget.items == [1, 2, 3]
+    assert widget.config == {'a': 1}
+
+
+# --- Auto-inferred type tests ---
+
+def test_only_as_set_infers_types():
+    """only as a set auto-infers types from property descriptors."""
+
+    class AutoState(HasCallbackProperties):
+        name = CallbackProperty('hello')
+        visible = CallbackProperty(True)
+        items = ListCallbackProperty([1, 2])
+        config = DictCallbackProperty({'a': 1})
+        choice = SelectionCallbackProperty(default_index=0)
+
+    AutoState.choice.set_choices(AutoState, ['x', 'y'])
+
+    state = AutoState()
+    widget = SimpleWidget()
+    handlers = autoconnect_callbacks_to_vue(
+        state, widget,
+        only={'name', 'visible', 'items', 'config', 'choice'},
+    )
+    assert set(handlers) == {'name', 'visible', 'items', 'config', 'choice'}
+
+    # Scalar properties use Any traitlet — bidirectional sync works
+    assert widget.name == 'hello'
+    state.name = 'world'
+    assert widget.name == 'world'
+    widget.name = 'back'
+    assert state.name == 'back'
+
+    assert widget.visible is True
+    state.visible = False
+    assert widget.visible is False
+
+    # List inferred from ListCallbackProperty
+    assert widget.items == [1, 2]
+    state.items.append(3)
+    assert widget.items == [1, 2, 3]
+
+    # Dict inferred from DictCallbackProperty
+    assert widget.config == {'a': 1}
+    state.config['b'] = 2
+    assert widget.config == {'a': 1, 'b': 2}
+
+    # Selection inferred from SelectionCallbackProperty
+    assert hasattr(widget, 'choice_items')
+    assert hasattr(widget, 'choice_selected')
+
+
+def test_any_handles_plain_list_value():
+    """connect_any works for a CallbackProperty whose value is a plain list."""
+
+    class PlainState(HasCallbackProperties):
+        open_panels = CallbackProperty([])
+
+    state = PlainState()
+    widget = SimpleWidget()
+    autoconnect_callbacks_to_vue(state, widget, only={'open_panels'})
+    assert widget.open_panels == []
+    state.open_panels = [0, 2]
+    assert widget.open_panels == [0, 2]
+    widget.open_panels = [1]
+    assert state.open_panels == [1]
+
+
+def test_infer_from_python_discovers_all():
+    """infer_properties_from='python' discovers all callback properties."""
+
+    class FullState(HasCallbackProperties):
+        name = CallbackProperty('hi')
+        items = ListCallbackProperty([1])
+        config = DictCallbackProperty({'a': 1})
+        _private = CallbackProperty('skip')  # should be skipped (starts with _)
+
+    state = FullState()
+    widget = SimpleWidget()
+    handlers = autoconnect_callbacks_to_vue(state, widget,
+                                            infer_properties_from='python')
+    assert set(handlers) == {'name', 'items', 'config'}
+
+    state.name = 'bye'
+    assert widget.name == 'bye'
+    state.items.append(2)
+    assert widget.items == [1, 2]
+    state.config['b'] = 2
+    assert widget.config == {'a': 1, 'b': 2}
+
+
+def test_infer_from_python_with_skip():
+    """infer_properties_from='python' respects the skip parameter."""
+
+    class SkipState(HasCallbackProperties):
+        a = CallbackProperty(1)
+        b = CallbackProperty(2)
+        c = CallbackProperty(3)
+
+    state = SkipState()
+    widget = SimpleWidget()
+    handlers = autoconnect_callbacks_to_vue(state, widget,
+                                            infer_properties_from='python',
+                                            skip={'b'})
+    assert 'a' in handlers
+    assert 'b' not in handlers
+    assert 'c' in handlers
+
+
+def test_infer_from_python_with_extras():
+    """infer_properties_from='python' + extras for custom transforms."""
+
+    class TransformState(HasCallbackProperties):
+        name = CallbackProperty('hello')
+        value = CallbackProperty(10)
+
+    state = TransformState()
+    widget = SimpleWidget()
+    handlers = autoconnect_callbacks_to_vue(
+        state, widget,
+        infer_properties_from='python',
+        extras={'value': ('text', str, int)},
+    )
+    # name auto-inferred as 'any', value overridden to 'text' with transforms
+    assert widget.name == 'hello'
+    assert widget.value == '10'
+    widget.value = '42'
+    assert state.value == 42

--- a/echo/vue/tests/test_autoconnect.py
+++ b/echo/vue/tests/test_autoconnect.py
@@ -682,7 +682,7 @@ def test_infer_from_python_with_extras():
 
     state = TransformState()
     widget = SimpleWidget()
-    handlers = autoconnect_callbacks_to_vue(
+    autoconnect_callbacks_to_vue(
         state, widget,
         infer_properties_from='python',
         extras={'value': ('text', str, int)},

--- a/echo/vue/tests/test_connect.py
+++ b/echo/vue/tests/test_connect.py
@@ -3,8 +3,10 @@ import pytest
 traitlets = pytest.importorskip("traitlets")
 
 from echo import CallbackProperty, SelectionCallbackProperty, HasCallbackProperties  # noqa: E402
+from echo import ListCallbackProperty, DictCallbackProperty  # noqa: E402
 from echo.vue._connect import (connect_bool, connect_float,  # noqa: E402
-                               connect_text, connect_choice)
+                               connect_text, connect_choice,
+                               connect_list, connect_dict, connect_any)
 
 
 class SimpleState(HasCallbackProperties):
@@ -193,6 +195,143 @@ class TestConnectChoice:
         current = state.color
         widget.color_selected = 99
         assert state.color == current
+
+
+class ContainerState(HasCallbackProperties):
+    items = ListCallbackProperty([{'name': 'a'}, {'name': 'b'}])
+    config = DictCallbackProperty({'x': 1, 'nested': {'y': 2}})
+    tags = ListCallbackProperty(['red', 'green'])
+    plain_list = CallbackProperty([0, 1])
+
+
+class TestConnectList:
+
+    def setup_method(self):
+        self.state = ContainerState()
+        self.widget = SimpleWidget()
+        self.conn = connect_list(self.state, 'items', self.widget)
+
+    def test_initial_sync(self):
+        assert self.widget.items == [{'name': 'a'}, {'name': 'b'}]
+
+    def test_state_to_widget(self):
+        self.state.items.append({'name': 'c'})
+        assert len(self.widget.items) == 3
+        assert self.widget.items[2] == {'name': 'c'}
+
+    def test_widget_to_state(self):
+        self.widget.items = [{'name': 'x'}]
+        assert len(self.state.items) == 1
+        assert self.state.items[0] == {'name': 'x'}
+
+    def test_in_place_update(self):
+        original = self.state.items
+        self.widget.items = [{'name': 'x'}, {'name': 'y'}]
+        assert self.state.items is original
+
+    def test_auto_create_trait(self):
+        state = ContainerState()
+        widget = SimpleWidget()
+        connect_list(state, 'tags', widget)
+        assert hasattr(widget, 'tags')
+        assert widget.tags == ['red', 'green']
+
+    def test_disconnect(self):
+        self.conn.disconnect()
+        self.state.items.append({'name': 'c'})
+        assert len(self.widget.items) == 2
+
+    def test_plain_list_fallback(self):
+        """CallbackProperty holding a plain list uses setattr instead of in-place."""
+        state = ContainerState()
+        widget = SimpleWidget()
+        connect_list(state, 'plain_list', widget)
+        assert widget.plain_list == [0, 1]
+        widget.plain_list = [3, 4]
+        assert state.plain_list == [3, 4]
+
+
+class TestConnectDict:
+
+    def setup_method(self):
+        self.state = ContainerState()
+        self.widget = SimpleWidget()
+        self.conn = connect_dict(self.state, 'config', self.widget)
+
+    def test_initial_sync(self):
+        assert self.widget.config == {'x': 1, 'nested': {'y': 2}}
+
+    def test_state_to_widget(self):
+        self.state.config['x'] = 99
+        assert self.widget.config['x'] == 99
+
+    def test_nested_mutation(self):
+        self.state.config['nested']['y'] = 42
+        assert self.widget.config['nested']['y'] == 42
+
+    def test_widget_to_state(self):
+        self.widget.config = {'x': 5, 'nested': {'y': 6}}
+        assert self.state.config['x'] == 5
+        assert self.state.config['nested']['y'] == 6
+
+    def test_in_place_update(self):
+        original = self.state.config
+        original_nested = self.state.config['nested']
+        self.widget.config = {'x': 5, 'nested': {'y': 6}}
+        assert self.state.config is original
+        assert self.state.config['nested'] is original_nested
+
+    def test_auto_create_trait(self):
+        state = ContainerState()
+        widget = SimpleWidget()
+        connect_dict(state, 'config', widget)
+        assert hasattr(widget, 'config')
+
+    def test_disconnect(self):
+        self.conn.disconnect()
+        self.state.config['x'] = 99
+        assert self.widget.config['x'] == 1
+
+
+class TestConnectAny:
+
+    def setup_method(self):
+        self.state = SimpleState()
+        self.widget = SimpleWidget()
+        self.conn = connect_any(self.state, 'name', self.widget)
+
+    def test_initial_sync(self):
+        assert self.widget.name == 'default'
+
+    def test_state_to_widget(self):
+        self.state.name = 'hello'
+        assert self.widget.name == 'hello'
+
+    def test_widget_to_state(self):
+        self.widget.name = 'world'
+        assert self.state.name == 'world'
+
+    def test_auto_create_trait(self):
+        state = SimpleState()
+        widget = SimpleWidget()
+        connect_any(state, 'height', widget)
+        assert hasattr(widget, 'height')
+        assert widget.height == 1.5
+
+    def test_disconnect(self):
+        self.conn.disconnect()
+        self.state.name = 'changed'
+        assert self.widget.name == 'default'
+
+    def test_no_type_coercion(self):
+        """connect_any passes values through without coercion."""
+        state = SimpleState()
+        widget = SimpleWidget()
+        connect_any(state, 'flag', widget)
+        state.flag = True
+        assert widget.flag is True
+        state.flag = 0
+        assert widget.flag == 0  # not coerced to bool
 
 
 @pytest.mark.parametrize('connect_cls, prop, initial, new_state, new_widget', [


### PR DESCRIPTION
Add ``connect_list``, ``connect_dict``, and ``connect_any`` handlers for syncing ``ListCallbackProperty``, ``DictCallbackProperty``, and generic ``CallbackProperty`` to Vue traitlets.

List/dict connections update containers in place to preserve attached callbacks.

Add ``infer_properties_from='python'`` mode which discovers all callback properties from the state class and infers types from the property classes, removing the need to list properties explicitly.

Allow the only parameter to accept a set of property names with types auto-inferred.